### PR TITLE
feat(pipelines, utils): add generic DataFrame output save utility and modularize input processing pipeline

### DIFF
--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/outputs/merged_data/merged_input.txt
+++ b/outputs/merged_data/merged_input.txt
@@ -1,0 +1,7614 @@
+sample;ko;genesymbol;genename;cpd;compoundclass;referenceAG;compoundname;enzyme_activity
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Acinetobacter Baumanii - acb;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Acinetobacter Baumanii - acb;K00528;fpr;ferredoxin/flavodoxin---NADP+ reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Acinetobacter Baumanii - acb;K00266;gltD;glutamate synthase (NADPH) small chain ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Acinetobacter Baumanii - acb;K00266;gltD;glutamate synthase (NADPH) small chain ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Acinetobacter Baumanii - acb;K00266;gltD;glutamate synthase (NADPH) small chain ;C11906;Inorganic;ATSDR;Sodium arsenite;synthase
+Acinetobacter Baumanii - acb;K00266;gltD;glutamate synthase (NADPH) small chain ;C11906;Metal;ATSDR;Sodium arsenite;synthase
+Acinetobacter Baumanii - acb;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;dioxygenase
+Acinetobacter Baumanii - acb;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;dioxygenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Acinetobacter Baumanii - acb;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Acinetobacter Baumanii - acb;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Acinetobacter Baumanii - acb;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Acinetobacter Baumanii - acb;K00355;NQO1;NAD(P)H dehydrogenase (quinone) ;C10312;Aromatic;IARC2B;Danthron;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;ATSDR;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C11344;Aliphatic;PSL;Methyl tert-butyl ether;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;EPC;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19302;Aliphatic;IARC2B;Thioacetamide;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C14440;Aliphatic;ATSDR;1,4-Dioxane;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;IARC2A;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19263;Aliphatic;IARC2B;Methyl isobutyl ketone;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;EPA;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;WFD;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C14440;Aliphatic;IARC2B;1,4-Dioxane;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C14687;Aliphatic;PSL;2-Ethoxyethanol;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Acinetobacter Baumanii - acb;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Acinetobacter Baumanii - acb;K00278;nadB;L-aspartate oxidase ;C19300;Inorganic;IARC2B;Tetranitromethane;oxidase
+Acinetobacter Baumanii - acb;K00278;nadB;L-aspartate oxidase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;oxidase
+Acinetobacter Baumanii - acb;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Acinetobacter Baumanii - acb;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Acinetobacter Baumanii - acb;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Acinetobacter Baumanii - acb;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Acinetobacter Baumanii - acb;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Acinetobacter Baumanii - acb;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Acinetobacter Baumanii - acb;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Acinetobacter Baumanii - acb;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Chlorinated;IARC2A;Nitrogen mustard;dehydrogenase
+Acinetobacter Baumanii - acb;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;dehydrogenase
+Acinetobacter Baumanii - acb;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Acinetobacter Baumanii - acb;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Acinetobacter Baumanii - acb;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Acinetobacter Baumanii - acb;K00496;alkB1_2;alkane 1-monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Acinetobacter Baumanii - acb;K00496;alkB1_2;alkane 1-monooxygenase ;C11344;Aliphatic;PSL;Methyl tert-butyl ether;monooxygenase
+Acinetobacter Baumanii - acb;K00496;alkB1_2;alkane 1-monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;ATSDR;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;WFD;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;EPC;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;PSL;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;PSL;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;EPC;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;WFD;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;ATSDR;3-Carboxy-cis,cis-muconate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dioxygenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;ATSDR;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C11344;Aliphatic;PSL;Methyl tert-butyl ether;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;EPC;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19302;Aliphatic;IARC2B;Thioacetamide;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C14440;Aliphatic;ATSDR;1,4-Dioxane;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;IARC2A;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19263;Aliphatic;IARC2B;Methyl isobutyl ketone;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;EPA;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06696;Metal;WFD;Lead;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C14440;Aliphatic;IARC2B;1,4-Dioxane;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C14687;Aliphatic;PSL;2-Ethoxyethanol;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;dehydrogenase
+Acinetobacter Baumanii - acb;K00001;E1.1.1.1;alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Acinetobacter Baumanii - acb;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Acinetobacter Baumanii - acb;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;EPC;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;EPC;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;WFD;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;ATSDR;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;WFD;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;ATSDR;Fluoranthene;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;EPA;Acenaphthene;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19304;Sulfur-containing;IARC2B;Thiouracil;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;WFD;Fluoranthene;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPA;Fluoranthene;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19304;Aliphatic;IARC2B;Thiouracil;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;ATSDR;Acenaphthene;chloroperoxidase
+Acinetobacter Baumanii - acb;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPC;Fluoranthene;chloroperoxidase
+Acinetobacter Baumanii - acb;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00823;puuE;4-aminobutyrate aminotransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;aminotransferase
+Acinetobacter Baumanii - acb;K00823;puuE;4-aminobutyrate aminotransferase ;C10984;Polyaromatic;EPC;Cypermethrin;aminotransferase
+Acinetobacter Baumanii - acb;K00823;puuE;4-aminobutyrate aminotransferase ;C10984;Chlorinated;EPC;Cypermethrin;aminotransferase
+Acinetobacter Baumanii - acb;K00823;puuE;4-aminobutyrate aminotransferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;aminotransferase
+Acinetobacter Baumanii - acb;K00823;puuE;4-aminobutyrate aminotransferase ;C19304;Aliphatic;IARC2B;Thiouracil;aminotransferase
+Acinetobacter Baumanii - acb;K00823;puuE;4-aminobutyrate aminotransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;aminotransferase
+Acinetobacter Baumanii - acb;K00299;ssuE;FMN reductase ;C00067;Aliphatic;PSL;Formaldehyde;reductase
+Acinetobacter Baumanii - acb;K00299;ssuE;FMN reductase ;C00067;Aliphatic;IARC1;Formaldehyde;reductase
+Acinetobacter Baumanii - acb;K00299;ssuE;FMN reductase ;C00067;Aliphatic;ATSDR;Formaldehyde;reductase
+Acinetobacter Baumanii - acb;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Acinetobacter Baumanii - acb;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Acinetobacter Baumanii - acb;K00287;DHFR;dihydrofolate reductase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Acinetobacter Baumanii - acb;K00560;thyA;thymidylate synthase ;C19239;Organosulfur;IARC2B;Ethyl methanesulfonate;synthase
+Acinetobacter Baumanii - acb;K00560;thyA;thymidylate synthase ;C19239;Aliphatic;IARC2B;Ethyl methanesulfonate;synthase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Acinetobacter Baumanii - acb;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Acinetobacter Baumanii - acb;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Acinetobacter Baumanii - acb;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Acinetobacter Baumanii - acb;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Acinetobacter Baumanii - acb;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Acinetobacter Baumanii - acb;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Acinetobacter Baumanii - acb;K00334;nuoE;NADH-quinone oxidoreductase subunit E ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00340;nuoK;NADH-quinone oxidoreductase subunit K ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Acinetobacter Baumanii - acb;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Acinetobacter Baumanii - acb;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Acinetobacter Baumanii - acb;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Acinetobacter Baumanii - acb;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Acinetobacter Baumanii - acb;K00331;nuoB;NADH-quinone oxidoreductase subunit B ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00335;nuoF;NADH-quinone oxidoreductase subunit F ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00337;nuoH;NADH-quinone oxidoreductase subunit H ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00338;nuoI;NADH-quinone oxidoreductase subunit I ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00339;nuoJ;NADH-quinone oxidoreductase subunit J ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00341;nuoL;NADH-quinone oxidoreductase subunit L ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00342;nuoM;NADH-quinone oxidoreductase subunit M ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00343;nuoN;NADH-quinone oxidoreductase subunit N ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Acinetobacter Baumanii - acb;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Acinetobacter Baumanii - acb;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Acinetobacter Baumanii - acb;K00528;fpr;ferredoxin/flavodoxin---NADP+ reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Acinetobacter Baumanii - acb;K00330;nuoA;NADH-quinone oxidoreductase subunit A ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;WFD;Mercuric chloride;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;ATSDR;Mercuric chloride;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C02116;Aliphatic;IARC2B;2-Nitropropane;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C00088;Nitrogen-containing;ATSDR;Nitrite;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC1;Acetaldehyde;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C00088;Inorganic;ATSDR;Nitrite;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;WFD;Mercuric chloride;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;monooxygenase
+Acinetobacter Baumanii - acb;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;PSL;Acetaldehyde;monooxygenase
+Acinetobacter Baumanii - acb;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Acinetobacter Baumanii - acb;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Acinetobacter Baumanii - acb;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Acinetobacter Baumanii - acb;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14219;Chlorinated;EPA;2-Chlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14219;Aromatic;ATSDR;2-Chlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C02625;Aromatic;CONAMA;2,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14219;Aromatic;CONAMA;2-Chlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14462;Chlorinated;CONAMA;3,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C02625;Aromatic;EPA;2,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C02625;Chlorinated;EPA;2,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C02625;Chlorinated;CONAMA;2,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C02625;Aromatic;ATSDR;2,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14462;Aromatic;CONAMA;3,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C02625;Chlorinated;ATSDR;2,4-Dichlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K10676;tfdB;2,4-dichlorophenol 6-monooxygenase ;C14219;Aromatic;EPA;2-Chlorophenol;monooxygenase
+Acinetobacter Baumanii - acb;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Chlorinated;IARC2A;Nitrogen mustard;dehydrogenase
+Acinetobacter Baumanii - acb;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;dehydrogenase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Acinetobacter Baumanii - acb;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;monooxygenase
+Acinetobacter Baumanii - acb;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;monooxygenase
+Acinetobacter Baumanii - acb;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;monooxygenase
+Acinetobacter Baumanii - acb;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;monooxygenase
+Acinetobacter Baumanii - acb;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Nitrogen-containing;IARC2A;Captafol;synthase
+Acinetobacter Baumanii - acb;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Sulfur-containing;IARC2A;Captafol;synthase
+Acinetobacter Baumanii - acb;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Chlorinated;IARC2A;Captafol;synthase
+Acinetobacter Baumanii - acb;K00362;nirB;nitrite reductase (NADH) large subunit ;C16038;Aromatic;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Acinetobacter Baumanii - acb;K00362;nirB;nitrite reductase (NADH) large subunit ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Acinetobacter Baumanii - acb;K00362;nirB;nitrite reductase (NADH) large subunit ;C16038;Nitrogen-containing;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Acinetobacter Baumanii - acb;K00362;nirB;nitrite reductase (NADH) large subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Acinetobacter Baumanii - acb;K00362;nirB;nitrite reductase (NADH) large subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Acinetobacter Baumanii - acb;K00362;nirB;nitrite reductase (NADH) large subunit ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Acinetobacter Baumanii - acb;K00265;gltB;glutamate synthase (NADPH) large chain ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Acinetobacter Baumanii - acb;K00265;gltB;glutamate synthase (NADPH) large chain ;C11906;Metal;ATSDR;Sodium arsenite;synthase
+Acinetobacter Baumanii - acb;K00265;gltB;glutamate synthase (NADPH) large chain ;C11906;Inorganic;ATSDR;Sodium arsenite;synthase
+Acinetobacter Baumanii - acb;K00265;gltB;glutamate synthase (NADPH) large chain ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Acinetobacter Baumanii - acb;K00261;GLUD1_2;glutamate dehydrogenase (NAD(P)+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00261;GLUD1_2;glutamate dehydrogenase (NAD(P)+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Acinetobacter Baumanii - acb;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Acinetobacter Baumanii - acb;K10679;nfnB;nitroreductase / dihydropteridine reductase ;C16391;Nitrogen-containing;ATSDR;Trinitrotoluene;nitroreductase
+Acinetobacter Baumanii - acb;K10679;nfnB;nitroreductase / dihydropteridine reductase ;C16391;Aromatic;ATSDR;Trinitrotoluene;nitroreductase
+Acinetobacter Baumanii - acb;K00336;nuoG;NADH-quinone oxidoreductase subunit G ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Acinetobacter Baumanii - acb;K13954;yiaY;alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K13954;yiaY;alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K13954;yiaY;alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Acinetobacter Baumanii - acb;K13954;yiaY;alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Acinetobacter Baumanii - acb;K13954;yiaY;alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K13954;yiaY;alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Acinetobacter Baumanii - acb;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Acinetobacter Baumanii - acb;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;WFD;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;WFD;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;EPC;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C15584;Aromatic;PSL;Phenol;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;CONAMA;Phenol;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;EPA;Phenol;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;ATSDR;Phenol;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;EPC;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;PSL;Phenol;thioesterase
+Acinetobacter Baumanii - acb;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;ATSDR;Chlorpyrifos;thioesterase
+Acinetobacter Baumanii - acb;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Acinetobacter Baumanii - acb;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Acinetobacter Baumanii - acb;K11263;bccA;acetyl-CoA/propionyl-CoA carboxylase, biotin carboxylase, biotin carboxyl carrier protein ;C11371;Polyaromatic;IARC2B;Nafenopin;carboxylase
+Acinetobacter Baumanii - acb;K13378;nuoCD;NADH-quinone oxidoreductase subunit C/D ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Acinetobacter Baumanii - acb;K13378;nuoCD;NADH-quinone oxidoreductase subunit C/D ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;oxidoreductase
+Acinetobacter Baumanii - acb;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Acinetobacter Baumanii - acb;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Acinetobacter Baumanii - acb;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Acinetobacter Baumanii - acb;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Acinetobacter Baumanii - acb;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Acinetobacter Baumanii - acb;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Acinetobacter Baumanii - acb;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Acinetobacter Baumanii - acb;K00024;mdh;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Acinetobacter Baumanii - acb;K00024;mdh;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Acinetobacter Baumanii - acb;K00024;mdh;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;ATSDR;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;IARC2B;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C00067;Aliphatic;ATSDR;Formaldehyde;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;ATSDR;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;EPA;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;PSL;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C00067;Aliphatic;IARC1;Formaldehyde;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;PSL;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C00067;Aliphatic;PSL;Formaldehyde;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;IARC2B;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;EPA;1,1,2,2-Tetrachloroethane;monooxygenase
+Acinetobacter Baumanii - acb;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Acinetobacter Baumanii - acb;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Acinetobacter Baumanii - acb;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Acinetobacter Baumanii - acb;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Acinetobacter Baumanii - acb;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K22589;thadh;threo-3-hydroxy-L-aspartate ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Acinetobacter Baumanii - acb;K22589;thadh;threo-3-hydroxy-L-aspartate ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Acinetobacter Baumanii - acb;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Acinetobacter Baumanii - acb;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Aromatic;IARC2A;Chloramphenicol;acetyltransferase
+Acinetobacter Baumanii - acb;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Chlorinated;IARC2A;Chloramphenicol;acetyltransferase
+Acinetobacter Baumanii - acb;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Nitrogen-containing;IARC2A;Chloramphenicol;acetyltransferase
+Acinetobacter Baumanii - acb;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Acinetobacter Baumanii - acb;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Acinetobacter Baumanii - acb;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Acinetobacter Baumanii - acb;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Acinetobacter Baumanii - acb;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Acinetobacter Baumanii - acb;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Acinetobacter Baumanii - acb;K21062;lhpC;1-pyrroline-4-hydroxy-2-carboxylate deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Acinetobacter Baumanii - acb;K21062;lhpC;1-pyrroline-4-hydroxy-2-carboxylate deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Acinetobacter Baumanii - acb;K21021;tpbB;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Acinetobacter Baumanii - acb;K21021;tpbB;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Acinetobacter Baumanii - acb;K21021;tpbB;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Acinetobacter Baumanii - acb;K21801;iaaH;indoleacetamide hydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;hydrolase
+Acinetobacter Baumanii - acb;K21801;iaaH;indoleacetamide hydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;hydrolase
+Acinetobacter Baumanii - acb;K21023;mucR;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Acinetobacter Baumanii - acb;K21023;mucR;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Acinetobacter Baumanii - acb;K21023;mucR;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Acinetobacter Baumanii - acb;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Acinetobacter Baumanii - acb;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Acinetobacter Baumanii - acb;K24158;prx;thioredoxin-dependent peroxiredoxin ;C19359;Chlorinated;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Acinetobacter Baumanii - acb;K24158;prx;thioredoxin-dependent peroxiredoxin ;C19359;Nitrogen-containing;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Acinetobacter Baumanii - acb;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Acinetobacter Baumanii - acb;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Acinetobacter Baumanii - acb;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Acinetobacter Baumanii - acb;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Acinetobacter Baumanii - acb;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Acinetobacter Baumanii - acb;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Aspergillus nidulans - ani;K00560;thyA;thymidylate synthase ;C19239;Organosulfur;IARC2B;Ethyl methanesulfonate;synthase
+Aspergillus nidulans - ani;K00560;thyA;thymidylate synthase ;C19239;Aliphatic;IARC2B;Ethyl methanesulfonate;synthase
+Aspergillus nidulans - ani;K20498;DSD1;D-serine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Aspergillus nidulans - ani;K20498;DSD1;D-serine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Aspergillus nidulans - ani;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;PSL;Styrene;decarboxylase
+Aspergillus nidulans - ani;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;CONAMA;Styrene;decarboxylase
+Aspergillus nidulans - ani;K20039;FDC1;phenacrylate decarboxylase ;C01197;Aromatic;IARC2B;Caffeate;decarboxylase
+Aspergillus nidulans - ani;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;IARC2A;Styrene;decarboxylase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Nitrogen-containing;WFD;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Aromatic;WFD;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Aromatic;ATSDR;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Chlorinated;ATSDR;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Aromatic;EPC;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Chlorinated;WFD;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Chlorinated;EPC;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Nitrogen-containing;ATSDR;Diuron;desaturase
+Aspergillus nidulans - ani;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Nitrogen-containing;EPC;Diuron;desaturase
+Aspergillus nidulans - ani;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Aspergillus nidulans - ani;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Aspergillus nidulans - ani;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Aliphatic;IARC2B;Thiouracil;synthase
+Aspergillus nidulans - ani;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;synthase
+Aspergillus nidulans - ani;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Sulfur-containing;IARC2B;Thiouracil;synthase
+Aspergillus nidulans - ani;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K14171;AHP1;alkyl hydroperoxide reductase 1 ;C19359;Nitrogen-containing;PSL;Chloramine;reductase
+Aspergillus nidulans - ani;K14171;AHP1;alkyl hydroperoxide reductase 1 ;C19359;Chlorinated;PSL;Chloramine;reductase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C00014;Nitrogen-containing;PSL;Ammonia;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13278;ASPG;60kDa lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K11446;KDM5;[histone H3]-trimethyl-L-lysine4 demethylase ;C00067;Aliphatic;IARC1;Formaldehyde;demethylase
+Aspergillus nidulans - ani;K11446;KDM5;[histone H3]-trimethyl-L-lysine4 demethylase ;C00067;Aliphatic;ATSDR;Formaldehyde;demethylase
+Aspergillus nidulans - ani;K11446;KDM5;[histone H3]-trimethyl-L-lysine4 demethylase ;C00067;Aliphatic;PSL;Formaldehyde;demethylase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;CONAMA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;ATSDR;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;EPA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;EPA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;IARC1;Formaldehyde;synthase
+Aspergillus nidulans - ani;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;PSL;Formaldehyde;synthase
+Aspergillus nidulans - ani;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;ATSDR;Formaldehyde;synthase
+Aspergillus nidulans - ani;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Inorganic;IARC2B;Tetranitromethane;monooxygenase
+Aspergillus nidulans - ani;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;monooxygenase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Inorganic;IARC2B;Tetranitromethane;monooxygenase
+Aspergillus nidulans - ani;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;monooxygenase
+Aspergillus nidulans - ani;K10675;E4.2.1.66;cyanide hydratase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;hydratase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;IARC1;Formaldehyde;synthase
+Aspergillus nidulans - ani;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;PSL;Formaldehyde;synthase
+Aspergillus nidulans - ani;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;ATSDR;Formaldehyde;synthase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06354;Polyaromatic;IARC2B;Benzophenone;dioxygenase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Polyaromatic;IARC2B;Mitomycin;dioxygenase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;dioxygenase
+Aspergillus nidulans - ani;K19823;NAO;nitroalkane oxidase ;C00084;Aliphatic;PSL;Acetaldehyde;oxidase
+Aspergillus nidulans - ani;K19823;NAO;nitroalkane oxidase ;C00088;Nitrogen-containing;ATSDR;Nitrite;oxidase
+Aspergillus nidulans - ani;K19823;NAO;nitroalkane oxidase ;C00084;Aliphatic;IARC2B;Acetaldehyde;oxidase
+Aspergillus nidulans - ani;K19823;NAO;nitroalkane oxidase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;oxidase
+Aspergillus nidulans - ani;K19823;NAO;nitroalkane oxidase ;C02116;Aliphatic;IARC2B;2-Nitropropane;oxidase
+Aspergillus nidulans - ani;K19823;NAO;nitroalkane oxidase ;C00084;Aliphatic;IARC1;Acetaldehyde;oxidase
+Aspergillus nidulans - ani;K19823;NAO;nitroalkane oxidase ;C00088;Inorganic;ATSDR;Nitrite;oxidase
+Aspergillus nidulans - ani;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Halogenated;IARC2B;Dibromoacetonitrile;dehydrogenase
+Aspergillus nidulans - ani;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Nitrogen-containing;IARC2B;Dibromoacetonitrile;dehydrogenase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;EPC;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;EPA;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;WFD;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;ATSDR;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C02116;Aliphatic;IARC2B;2-Nitropropane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00088;Nitrogen-containing;ATSDR;Nitrite;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC1;Acetaldehyde;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00088;Inorganic;ATSDR;Nitrite;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;WFD;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;PSL;Acetaldehyde;monooxygenase
+Aspergillus nidulans - ani;K00637;SOAT;sterol O-acyltransferase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;acyltransferase
+Aspergillus nidulans - ani;K00637;SOAT;sterol O-acyltransferase ;C19300;Inorganic;IARC2B;Tetranitromethane;acyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Inorganic;IARC2B;Tetranitromethane;dehydrogenase
+Aspergillus nidulans - ani;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;dehydrogenase
+Aspergillus nidulans - ani;K00965;galT;UDPglucose--hexose-1-phosphate uridylyltransferase ;C19262;Nitrogen-containing;IARC2B;4-Methylimidazole;uridylyltransferase
+Aspergillus nidulans - ani;K00965;galT;UDPglucose--hexose-1-phosphate uridylyltransferase ;C19262;Aliphatic;IARC2B;4-Methylimidazole;uridylyltransferase
+Aspergillus nidulans - ani;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Aspergillus nidulans - ani;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K00264;GLT1;glutamate synthase (NADH) ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Aspergillus nidulans - ani;K00264;GLT1;glutamate synthase (NADH) ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Inorganic;IARC2B;Cobaltous sulfate;deaminase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Metal;IARC2B;Cobaltous sulfate;deaminase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Aspergillus nidulans - ani;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidase
+Aspergillus nidulans - ani;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;PSL;Ammonia;amidase
+Aspergillus nidulans - ani;K13996;EPS1;protein disulfide-isomerase ;C14365;Chlorinated;ATSDR;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Aspergillus nidulans - ani;K13996;EPS1;protein disulfide-isomerase ;C14365;Polyaromatic;ATSDR;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Aspergillus nidulans - ani;K13996;EPS1;protein disulfide-isomerase ;C14365;Polyaromatic;IARC1;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Aspergillus nidulans - ani;K13996;EPS1;protein disulfide-isomerase ;C14365;Chlorinated;IARC1;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Aspergillus nidulans - ani;K13996;EPS1;protein disulfide-isomerase ;C14462;Aromatic;CONAMA;3,4-Dichlorophenol;isomerase
+Aspergillus nidulans - ani;K13996;EPS1;protein disulfide-isomerase ;C14462;Chlorinated;CONAMA;3,4-Dichlorophenol;isomerase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Organometallic;WFD;Methylmercury chloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Chlorinated;IARC2B;Methylmercury chloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;EPA;Carbon tetrachloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Chlorinated;EPC;Methylmercury chloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;EPC;Carbon tetrachloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Chlorinated;WFD;Methylmercury chloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C19302;Aliphatic;IARC2B;Thioacetamide;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Organometallic;EPC;Methylmercury chloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Organometallic;IARC2B;Methylmercury chloride;ligase
+Aspergillus nidulans - ani;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C19302;Sulfur-containing;IARC2B;Thioacetamide;ligase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Aspergillus nidulans - ani;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Aspergillus nidulans - ani;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K10777;LIG4;DNA ligase 4 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Aspergillus nidulans - ani;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Aspergillus nidulans - ani;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K11541;URA2;carbamoyl-phosphate synthase / aspartate carbamoyltransferase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Aspergillus nidulans - ani;K11541;URA2;carbamoyl-phosphate synthase / aspartate carbamoyltransferase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Aspergillus nidulans - ani;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Nitrogen-containing;IARC2B;Merphalan;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Nitrogen-containing;IARC2A;Phenacetin;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Aromatic;IARC2B;Merphalan;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Aromatic;IARC2A;Phenacetin;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Chlorinated;IARC2B;Merphalan;dipeptidase
+Aspergillus nidulans - ani;K00866;CKI1;choline kinase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;kinase
+Aspergillus nidulans - ani;K00866;CKI1;choline kinase ;C07561;Chlorinated;EPC;Carbon tetrachloride;kinase
+Aspergillus nidulans - ani;K00866;CKI1;choline kinase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;kinase
+Aspergillus nidulans - ani;K00866;CKI1;choline kinase ;C07561;Chlorinated;EPA;Carbon tetrachloride;kinase
+Aspergillus nidulans - ani;K00866;CKI1;choline kinase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;kinase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Aspergillus nidulans - ani;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Aspergillus nidulans - ani;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Aspergillus nidulans - ani;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Aspergillus nidulans - ani;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Aspergillus nidulans - ani;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Aspergillus nidulans - ani;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Aspergillus nidulans - ani;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Aspergillus nidulans - ani;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Aspergillus nidulans - ani;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Nitrogen-containing;IARC2B;Streptozocin;acetyltransferase
+Aspergillus nidulans - ani;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Aliphatic;IARC2B;Streptozocin;acetyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dehydratase
+Aspergillus nidulans - ani;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dehydratase
+Aspergillus nidulans - ani;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dehydratase
+Aspergillus nidulans - ani;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dehydratase
+Aspergillus nidulans - ani;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;WFD;3-Carboxy-cis,cis-muconate;cyclase
+Aspergillus nidulans - ani;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;ATSDR;3-Carboxy-cis,cis-muconate;cyclase
+Aspergillus nidulans - ani;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;EPC;3-Carboxy-cis,cis-muconate;cyclase
+Aspergillus nidulans - ani;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;PSL;3-Carboxy-cis,cis-muconate;cyclase
+Aspergillus nidulans - ani;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Aspergillus nidulans - ani;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Aspergillus nidulans - ani;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Aspergillus nidulans - ani;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Aspergillus nidulans - ani;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Aspergillus nidulans - ani;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Aspergillus nidulans - ani;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Aspergillus nidulans - ani;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Aspergillus nidulans - ani;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Aspergillus nidulans - ani;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Aspergillus nidulans - ani;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Chlorinated;IARC2A;Nitrogen mustard;dehydrogenase
+Aspergillus nidulans - ani;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;dehydrogenase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Nitrogen-containing;IARC1;Aristolochic acid;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;PSL;Dibutyl phthalate;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;ATSDR;Dibutyl phthalate;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;EPA;Dibutyl phthalate;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Polyaromatic;IARC1;Aristolochic acid;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;EPC;Tributyltin oxide;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C19309;Aliphatic;IARC2B;Vinyl acetate;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;CONAMA;Dibutyl phthalate;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;WFD;Tributyltin oxide;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;EPC;Tributyltin oxide;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14175;Aromatic;EPA;Diethyl phthalate;lipase
+Aspergillus nidulans - ani;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;WFD;Tributyltin oxide;lipase
+Aspergillus nidulans - ani;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Aspergillus nidulans - ani;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Aspergillus nidulans - ani;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Aspergillus nidulans - ani;K11415;SIRT5;NAD-dependent protein deacetylase sirtuin 5 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K11415;SIRT5;NAD-dependent protein deacetylase sirtuin 5 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06354;Polyaromatic;IARC2B;Benzophenone;dioxygenase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Polyaromatic;IARC2B;Mitomycin;dioxygenase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;dioxygenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;ATSDR;Butylbenzyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;PSL;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;IARC2B;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;EPA;Butylbenzyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;PSL;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;PSL;Butylbenzyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;ATSDR;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;CONAMA;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;WFD;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;EPA;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14227;Aromatic;PSL;Di-n-octyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;EPC;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14205;Aromatic;EPC;4-tert-Octylphenol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;ATSDR;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14227;Aromatic;EPA;Di-n-octyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14205;Aromatic;WFD;4-tert-Octylphenol;methyltransferase
+Aspergillus nidulans - ani;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;aminotransferase
+Aspergillus nidulans - ani;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Aliphatic;IARC2B;Thiouracil;aminotransferase
+Aspergillus nidulans - ani;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Chlorinated;EPC;Cypermethrin;aminotransferase
+Aspergillus nidulans - ani;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Sulfur-containing;IARC2B;Thiouracil;aminotransferase
+Aspergillus nidulans - ani;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Polyaromatic;EPC;Cypermethrin;aminotransferase
+Aspergillus nidulans - ani;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Nitrogen-containing;EPC;Cypermethrin;aminotransferase
+Aspergillus nidulans - ani;K00643;E2.3.1.37;5-aminolevulinate synthase ;C19233;Aliphatic;IARC2B;1,1-Dimethylhydrazine;synthase
+Aspergillus nidulans - ani;K00643;E2.3.1.37;5-aminolevulinate synthase ;C19233;Nitrogen-containing;IARC2B;1,1-Dimethylhydrazine;synthase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;CONAMA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;ATSDR;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;EPA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;EPA;2-Chlorophenol;xylosidase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Inorganic;IARC2B;Cobaltous sulfate;deaminase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Metal;IARC2B;Cobaltous sulfate;deaminase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Aspergillus nidulans - ani;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06354;Polyaromatic;IARC2B;Benzophenone;dioxygenase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Polyaromatic;IARC2B;Mitomycin;dioxygenase
+Aspergillus nidulans - ani;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;dioxygenase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C07675;Aromatic;IARC2A;Pioglitazone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C19263;Aliphatic;IARC2B;Methyl isobutyl ketone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Aspergillus nidulans - ani;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;EPC;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;EPA;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K10759;E3.1.1.20;tannase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;tannase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Aspergillus nidulans - ani;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Aspergillus nidulans - ani;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C19306;Nitrogen-containing;IARC2B;Trp-P-1;polymerase
+Aspergillus nidulans - ani;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C14416;Nitrogen-containing;IARC2B;Trp-P-2;polymerase
+Aspergillus nidulans - ani;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C19306;Aromatic;IARC2B;Trp-P-1;polymerase
+Aspergillus nidulans - ani;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C14416;Aromatic;IARC2B;Trp-P-2;polymerase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C07675;Aromatic;IARC2A;Pioglitazone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C19263;Aliphatic;IARC2B;Methyl isobutyl ketone;oxidase
+Aspergillus nidulans - ani;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K19357;CELB;cellulase ;C01783;Organometallic;WFD;Arylmercury;cellulase
+Aspergillus nidulans - ani;K19357;CELB;cellulase ;C01783;Polyaromatic;EPC;Arylmercury;cellulase
+Aspergillus nidulans - ani;K19357;CELB;cellulase ;C01783;Organometallic;EPC;Arylmercury;cellulase
+Aspergillus nidulans - ani;K19357;CELB;cellulase ;C01783;Polyaromatic;WFD;Arylmercury;cellulase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;ATSDR;Butylbenzyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;PSL;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;IARC2B;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;EPA;Butylbenzyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;PSL;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;PSL;Butylbenzyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;ATSDR;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;CONAMA;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;WFD;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;EPA;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14227;Aromatic;PSL;Di-n-octyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;EPC;Catechol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14205;Aromatic;EPC;4-tert-Octylphenol;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;ATSDR;Dibutyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14227;Aromatic;EPA;Di-n-octyl phthalate;methyltransferase
+Aspergillus nidulans - ani;K00545;COMT;catechol O-methyltransferase ;C14205;Aromatic;WFD;4-tert-Octylphenol;methyltransferase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Aspergillus nidulans - ani;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Aspergillus nidulans - ani;K22213;PATG;6-methylsalicylate decarboxylase ;C01467;Aromatic;EPA;3-Cresol;decarboxylase
+Aspergillus nidulans - ani;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Aspergillus nidulans - ani;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Aspergillus nidulans - ani;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Aspergillus nidulans - ani;K11187;PRDX5;peroxiredoxin 5 ;C19359;Chlorinated;PSL;Chloramine;peroxiredoxin 5
+Aspergillus nidulans - ani;K11187;PRDX5;peroxiredoxin 5 ;C19359;Nitrogen-containing;PSL;Chloramine;peroxiredoxin 5
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Aspergillus nidulans - ani;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Aspergillus nidulans - ani;K11126;TERT;telomerase reverse transcriptase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;telomerase
+Aspergillus nidulans - ani;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Aspergillus nidulans - ani;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K17989;SDS;L-serine/L-threonine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Aspergillus nidulans - ani;K17989;SDS;L-serine/L-threonine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Aspergillus nidulans - ani;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Aspergillus nidulans - ani;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Aspergillus nidulans - ani;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Chlorinated;IARC2B;Nitrofen;oxidase
+Aspergillus nidulans - ani;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Nitrogen-containing;IARC2B;Nitrofen;oxidase
+Aspergillus nidulans - ani;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Polyaromatic;IARC2B;Nitrofen;oxidase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K15440;TAD1;tRNA-specific adenosine deaminase 1 ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Aspergillus nidulans - ani;K15440;TAD1;tRNA-specific adenosine deaminase 1 ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;WFD;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;ATSDR;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C02116;Aliphatic;IARC2B;2-Nitropropane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00088;Nitrogen-containing;ATSDR;Nitrite;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC1;Acetaldehyde;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00088;Inorganic;ATSDR;Nitrite;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;WFD;Mercuric chloride;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;monooxygenase
+Aspergillus nidulans - ani;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;PSL;Acetaldehyde;monooxygenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K17989;SDS;L-serine/L-threonine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Aspergillus nidulans - ani;K17989;SDS;L-serine/L-threonine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;EPA;Heptachlor;kinase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;EPC;Heptachlor;kinase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;EPA;Heptachlor;kinase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;EPC;Heptachlor;kinase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;IARC2B;Heptachlor;kinase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;ATSDR;Heptachlor;kinase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;IARC2B;Heptachlor;kinase
+Aspergillus nidulans - ani;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;ATSDR;Heptachlor;kinase
+Aspergillus nidulans - ani;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Aspergillus nidulans - ani;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Aspergillus nidulans - ani;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Aspergillus nidulans - ani;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Aspergillus nidulans - ani;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Aromatic;IARC2A;Pioglitazone;kinase
+Aspergillus nidulans - ani;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;kinase
+Aspergillus nidulans - ani;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;kinase
+Aspergillus nidulans - ani;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Aspergillus nidulans - ani;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Aspergillus nidulans - ani;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Aspergillus nidulans - ani;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Aspergillus nidulans - ani;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Aspergillus nidulans - ani;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Aspergillus nidulans - ani;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Aspergillus nidulans - ani;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Halogenated;IARC2B;Dibromoacetonitrile;dehydrogenase
+Aspergillus nidulans - ani;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Nitrogen-containing;IARC2B;Dibromoacetonitrile;dehydrogenase
+Aspergillus nidulans - ani;K14264;BNA3;kynurenine aminotransferase ;C13672;Aliphatic;WFD;AMPA;aminotransferase
+Aspergillus nidulans - ani;K14264;BNA3;kynurenine aminotransferase ;C13672;Nitrogen-containing;WFD;AMPA;aminotransferase
+Aspergillus nidulans - ani;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Aspergillus nidulans - ani;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Nitrogen-containing;IARC2B;Merphalan;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Nitrogen-containing;IARC2A;Phenacetin;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Aromatic;IARC2B;Merphalan;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Aromatic;IARC2A;Phenacetin;dipeptidase
+Aspergillus nidulans - ani;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Chlorinated;IARC2B;Merphalan;dipeptidase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Aspergillus nidulans - ani;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00009;mtlD;mannitol-1-phosphate 5-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00009;mtlD;mannitol-1-phosphate 5-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K10775;PAL;phenylalanine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Aspergillus nidulans - ani;K10775;PAL;phenylalanine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Aspergillus nidulans - ani;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Aspergillus nidulans - ani;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Aspergillus nidulans - ani;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Aspergillus nidulans - ani;K00287;DHFR;dihydrofolate reductase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Aspergillus nidulans - ani;K11262;ACACA;acetyl-CoA carboxylase / biotin carboxylase 1 ;C11371;Polyaromatic;IARC2B;Nafenopin;carboxylase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Aspergillus nidulans - ani;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;PSL;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;EPC;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;EPA;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;EPA;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;EPC;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;ATSDR;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;WFD;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;ATSDR;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;PSL;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;WFD;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Aspergillus nidulans - ani;K16794;PAFAH1B1;platelet-activating factor acetylhydrolase IB subunit alpha;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acetylhydrolase
+Aspergillus nidulans - ani;K16794;PAFAH1B1;platelet-activating factor acetylhydrolase IB subunit alpha;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acetylhydrolase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C08469;Polyaromatic;IARC1;Aristolochic acid;phospholipase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Metal;WFD;Tributyltin oxide;phospholipase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Organometallic;EPC;Tributyltin oxide;phospholipase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;phospholipase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Metal;EPC;Tributyltin oxide;phospholipase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Organometallic;WFD;Tributyltin oxide;phospholipase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;phospholipase
+Aspergillus nidulans - ani;K16342;PLA2G4;cytosolic phospholipase A2 ;C08469;Nitrogen-containing;IARC1;Aristolochic acid;phospholipase
+Aspergillus nidulans - ani;K20247;EGT2;hercynylcysteine S-oxide lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Aspergillus nidulans - ani;K20247;EGT2;hercynylcysteine S-oxide lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Aspergillus nidulans - ani;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Nitrogen-containing;IARC2B;Streptozocin;acetyltransferase
+Aspergillus nidulans - ani;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Aliphatic;IARC2B;Streptozocin;acetyltransferase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K13519;LPT1;lysophospholipid acyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Aspergillus nidulans - ani;K13519;LPT1;lysophospholipid acyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Aspergillus nidulans - ani;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;PSL;Ammonia;synthetase
+Aspergillus nidulans - ani;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthetase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;PSL;Catechol;decarboxylase
+Aspergillus nidulans - ani;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;EPC;Catechol;decarboxylase
+Aspergillus nidulans - ani;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;ATSDR;Catechol;decarboxylase
+Aspergillus nidulans - ani;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;IARC2B;Catechol;decarboxylase
+Aspergillus nidulans - ani;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;WFD;Catechol;decarboxylase
+Aspergillus nidulans - ani;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Aspergillus nidulans - ani;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Aspergillus nidulans - ani;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Aspergillus nidulans - ani;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Aspergillus nidulans - ani;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Aspergillus nidulans - ani;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Aspergillus nidulans - ani;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;PSL;Formaldehyde;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;WFD;Benzo[a]pyrene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19594;Aromatic;IARC1;Aflatoxin-M1-8,9-epoxide;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;IARC1;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;CONAMA;Benzo[a]pyrene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;ATSDR;Formaldehyde;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16756;Aromatic;IARC2B;Aflatoxin M1;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14866;Chlorinated;IARC2A;Chloral;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;PSL;Benzo[a]pyrene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19585;Aromatic;IARC1;Aflatoxin Q1;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;PSL;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16038;Aromatic;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;IARC2B;Naphthalene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;EPA;Naphthalene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;EPA;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;EPA;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;EPC;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;ATSDR;Benzo[a]pyrene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;PSL;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;IARC1;Formaldehyde;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;ATSDR;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;CONAMA;Naphthalene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Organophosphorus;IARC2B;Parathion;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;CONAMA;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;EPC;Naphthalene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07108;Polyaromatic;IARC1;Tamoxifen;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;IARC1;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;IARC1;Benzo[a]pyrene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;EPC;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19312;Polyaromatic;ATSDR;Acenaphthene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19595;Aromatic;IARC1;Aflatoxin B1-endo-8,9-epoxide;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06800;Aromatic;IARC1;Aflatoxin B1;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;ATSDR;Naphthalene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16453;Nitrogen-containing;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Aromatic;ATSDR;Parathion;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Organophosphorus;ATSDR;Parathion;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;EPC;Benzo[a]pyrene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;CONAMA;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16038;Nitrogen-containing;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19312;Polyaromatic;EPA;Acenaphthene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Aromatic;IARC2B;Parathion;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Nitrogen-containing;IARC2B;Parathion;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;WFD;Naphthalene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14866;Aliphatic;IARC2A;Chloral;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07108;Nitrogen-containing;IARC1;Tamoxifen;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;EPA;Benzo[a]pyrene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16453;Aliphatic;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;ATSDR;Trichloroethene;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16756;Aromatic;IARC1;Aflatoxin M1;reductase
+Aspergillus nidulans - ani;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Nitrogen-containing;ATSDR;Parathion;reductase
+Aspergillus nidulans - ani;K13501;TRP1;anthranilate synthase / indole-3-glycerol phosphate synthase / phosphoribosylanthranilate isomerase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Aspergillus nidulans - ani;K13501;TRP1;anthranilate synthase / indole-3-glycerol phosphate synthase / phosphoribosylanthranilate isomerase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Aspergillus nidulans - ani;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;dioxygenase
+Aspergillus nidulans - ani;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;dioxygenase
+Aspergillus nidulans - ani;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Nitrogen-containing;IARC2A;Captafol;synthase
+Aspergillus nidulans - ani;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Sulfur-containing;IARC2A;Captafol;synthase
+Aspergillus nidulans - ani;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Chlorinated;IARC2A;Captafol;synthase
+Aspergillus nidulans - ani;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Aspergillus nidulans - ani;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Aspergillus nidulans - ani;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Inorganic;IARC2B;Tetranitromethane;dehydrogenase
+Aspergillus nidulans - ani;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;dehydrogenase
+Aspergillus nidulans - ani;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K00877;THI20;hydroxymethylpyrimidine/phosphomethylpyrimidine kinase / thiaminase ;C00014;Nitrogen-containing;PSL;Ammonia;kinase
+Aspergillus nidulans - ani;K00877;THI20;hydroxymethylpyrimidine/phosphomethylpyrimidine kinase / thiaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;kinase
+Aspergillus nidulans - ani;K11414;SIRT4;NAD-dependent protein deacetylase/lipoamidase sirtuin 4 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Aspergillus nidulans - ani;K11414;SIRT4;NAD-dependent protein deacetylase/lipoamidase sirtuin 4 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Chlorella variabilis - cvr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Chlorella variabilis - cvr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Chlorella variabilis - cvr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Chlorella variabilis - cvr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Chlorella variabilis - cvr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Chlorella variabilis - cvr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Chlorella variabilis - cvr;K23998;PPOX;pyridoxal 5'-phosphate synthase / NAD(P)H-hydrate epimerase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Chlorella variabilis - cvr;K23998;PPOX;pyridoxal 5'-phosphate synthase / NAD(P)H-hydrate epimerase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Chlorella variabilis - cvr;K21456;GSS;glutathione synthase ;C19302;Aliphatic;IARC2B;Thioacetamide;synthase
+Chlorella variabilis - cvr;K21456;GSS;glutathione synthase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;synthase
+Chlorella variabilis - cvr;K21456;GSS;glutathione synthase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;synthase
+Chlorella variabilis - cvr;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Chlorella variabilis - cvr;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Chlorella variabilis - cvr;K18151;UAH;ureidoglycolate amidohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;amidohydrolase
+Chlorella variabilis - cvr;K18151;UAH;ureidoglycolate amidohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidohydrolase
+Chlorella variabilis - cvr;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Chlorella variabilis - cvr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Chlorella variabilis - cvr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Chlorella variabilis - cvr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Chlorella variabilis - cvr;K21480;HO;heme oxygenase (biliverdin-producing, ferredoxin) ;C00237;Inorganic;ATSDR;CO;oxygenase
+Chlorella variabilis - cvr;K21480;HO;heme oxygenase (biliverdin-producing, ferredoxin) ;C00237;Inorganic;ATSDR;CO;oxygenase
+Chlorella variabilis - cvr;K14662;NTAN1;protein N-terminal asparagine amidohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidohydrolase
+Chlorella variabilis - cvr;K14662;NTAN1;protein N-terminal asparagine amidohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;amidohydrolase
+Chlorella variabilis - cvr;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;PSL;Ammonia;synthetase
+Chlorella variabilis - cvr;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthetase
+Chlorella variabilis - cvr;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;PSL;Ammonia;synthetase
+Chlorella variabilis - cvr;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthetase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K14395;ACP6;lysophosphatidic acid phosphatase type 6 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14395;ACP6;lysophosphatidic acid phosphatase type 6 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14395;ACP6;lysophosphatidic acid phosphatase type 6 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14395;ACP6;lysophosphatidic acid phosphatase type 6 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14395;ACP6;lysophosphatidic acid phosphatase type 6 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14395;ACP6;lysophosphatidic acid phosphatase type 6 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14395;ACP6;lysophosphatidic acid phosphatase type 6 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Chlorella variabilis - cvr;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Chlorella variabilis - cvr;K17285;SELENBP1;methanethiol oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K17285;SELENBP1;methanethiol oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K17285;SELENBP1;methanethiol oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K17285;SELENBP1;methanethiol oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K17285;SELENBP1;methanethiol oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K17285;SELENBP1;methanethiol oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K14286;AGXT2L1;ethanolamine-phosphate phospho-lyase ;C00084;Aliphatic;PSL;Acetaldehyde;lyase
+Chlorella variabilis - cvr;K14286;AGXT2L1;ethanolamine-phosphate phospho-lyase ;C00084;Aliphatic;IARC2B;Acetaldehyde;lyase
+Chlorella variabilis - cvr;K14286;AGXT2L1;ethanolamine-phosphate phospho-lyase ;C00084;Aliphatic;IARC1;Acetaldehyde;lyase
+Chlorella variabilis - cvr;K14286;AGXT2L1;ethanolamine-phosphate phospho-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Chlorella variabilis - cvr;K14286;AGXT2L1;ethanolamine-phosphate phospho-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Chlorella variabilis - cvr;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Nitrogen-containing;IARC2A;Captafol;synthase
+Chlorella variabilis - cvr;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Sulfur-containing;IARC2A;Captafol;synthase
+Chlorella variabilis - cvr;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Chlorinated;IARC2A;Captafol;synthase
+Chlorella variabilis - cvr;K11412;SIRT2;NAD-dependent protein deacetylase sirtuin 2 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Chlorella variabilis - cvr;K11412;SIRT2;NAD-dependent protein deacetylase sirtuin 2 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K21552;HOL;methyl halide transferase ;C19446;Chlorinated;ATSDR;Methyl chloride;transferase
+Chlorella variabilis - cvr;K21552;HOL;methyl halide transferase ;C18447;Halogenated;EPA;Methyl bromide;transferase
+Chlorella variabilis - cvr;K21552;HOL;methyl halide transferase ;C19446;Aliphatic;ATSDR;Methyl chloride;transferase
+Chlorella variabilis - cvr;K21552;HOL;methyl halide transferase ;C18447;Aliphatic;EPA;Methyl bromide;transferase
+Chlorella variabilis - cvr;K21552;HOL;methyl halide transferase ;C19446;Aliphatic;EPA;Methyl chloride;transferase
+Chlorella variabilis - cvr;K21552;HOL;methyl halide transferase ;C19446;Chlorinated;EPA;Methyl chloride;transferase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Chlorella variabilis - cvr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Chlorella variabilis - cvr;K11416;SIRT6;NAD-dependent protein deacetylase sirtuin 6 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Chlorella variabilis - cvr;K11416;SIRT6;NAD-dependent protein deacetylase sirtuin 6 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Chlorella variabilis - cvr;K13519;LPT1;lysophospholipid acyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Chlorella variabilis - cvr;K13519;LPT1;lysophospholipid acyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Chlorella variabilis - cvr;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Chlorella variabilis - cvr;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Chlorella variabilis - cvr;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Nitrogen-containing;IARC2B;Merphalan;dipeptidase
+Chlorella variabilis - cvr;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Nitrogen-containing;IARC2A;Phenacetin;dipeptidase
+Chlorella variabilis - cvr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Aromatic;IARC2B;Merphalan;dipeptidase
+Chlorella variabilis - cvr;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Aromatic;IARC2A;Phenacetin;dipeptidase
+Chlorella variabilis - cvr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Chlorinated;IARC2B;Merphalan;dipeptidase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Nitrogen-containing;IARC1;Aristolochic acid;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;PSL;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;ATSDR;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;EPA;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Polyaromatic;IARC1;Aristolochic acid;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;EPC;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C19309;Aliphatic;IARC2B;Vinyl acetate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;CONAMA;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;WFD;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;EPC;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14175;Aromatic;EPA;Diethyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;WFD;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidase
+Chlorella variabilis - cvr;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;PSL;Ammonia;amidase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Nitrogen-containing;IARC1;Aristolochic acid;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;PSL;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;ATSDR;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;EPA;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Polyaromatic;IARC1;Aristolochic acid;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;EPC;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C19309;Aliphatic;IARC2B;Vinyl acetate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;CONAMA;Dibutyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;WFD;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;EPC;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14175;Aromatic;EPA;Diethyl phthalate;lipase
+Chlorella variabilis - cvr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;WFD;Tributyltin oxide;lipase
+Chlorella variabilis - cvr;K22450;SNAT;aralkylamine N-acetyltransferase ;C07591;Aromatic;IARC2A;Phenacetin;acetyltransferase
+Chlorella variabilis - cvr;K22450;SNAT;aralkylamine N-acetyltransferase ;C07591;Nitrogen-containing;IARC2A;Phenacetin;acetyltransferase
+Chlorella variabilis - cvr;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;kinase
+Chlorella variabilis - cvr;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;kinase
+Chlorella variabilis - cvr;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;EPA;Carbon tetrachloride;kinase
+Chlorella variabilis - cvr;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;EPC;Carbon tetrachloride;kinase
+Chlorella variabilis - cvr;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;kinase
+Chlorella variabilis - cvr;K16329;psuG;pseudouridylate synthase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;synthase
+Chlorella variabilis - cvr;K16329;psuG;pseudouridylate synthase ;C19304;Aliphatic;IARC2B;Thiouracil;synthase
+Chlorella variabilis - cvr;K16329;psuG;pseudouridylate synthase ;C19304;Sulfur-containing;IARC2B;Thiouracil;synthase
+Chlorella variabilis - cvr;K14977;ylbA;(S)-ureidoglycine aminohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;aminohydrolase
+Chlorella variabilis - cvr;K14977;ylbA;(S)-ureidoglycine aminohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminohydrolase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Chlorella variabilis - cvr;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Chlorella variabilis - cvr;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Chlorella variabilis - cvr;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;dioxygenase
+Chlorella variabilis - cvr;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;dioxygenase
+Chlorella variabilis - cvr;K20547;CHIB;basic endochitinase B ;C14321;Polyaromatic;ATSDR;Benzo[k]fluoranthene;endochitinase
+Chlorella variabilis - cvr;K20547;CHIB;basic endochitinase B ;C14321;Polyaromatic;IARC2B;Benzo[k]fluoranthene;endochitinase
+Chlorella variabilis - cvr;K20547;CHIB;basic endochitinase B ;C14321;Polyaromatic;EPA;Benzo[k]fluoranthene;endochitinase
+Chlorella variabilis - cvr;K20547;CHIB;basic endochitinase B ;C14321;Polyaromatic;EPC;Benzo[k]fluoranthene;endochitinase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K11187;PRDX5;peroxiredoxin 5 ;C19359;Chlorinated;PSL;Chloramine;peroxiredoxin 5
+Chlorella variabilis - cvr;K11187;PRDX5;peroxiredoxin 5 ;C19359;Nitrogen-containing;PSL;Chloramine;peroxiredoxin 5
+Chlorella variabilis - cvr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Chlorella variabilis - cvr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Chlorella variabilis - cvr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Chlorella variabilis - cvr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00857;tdk;thymidine kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Chlorella variabilis - cvr;K00857;tdk;thymidine kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Chlorella variabilis - cvr;K15877;CYP55;fungal nitric oxide reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Chlorella variabilis - cvr;K15877;CYP55;fungal nitric oxide reductase ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Chlorella variabilis - cvr;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Aliphatic;WFD;AMPA;aminotransferase
+Chlorella variabilis - cvr;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Nitrogen-containing;WFD;AMPA;aminotransferase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Chlorella variabilis - cvr;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Chlorella variabilis - cvr;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Chlorella variabilis - cvr;K00757;udp;uridine phosphorylase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;phosphorylase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;PSL;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;EPC;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;EPA;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;EPA;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;EPC;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;ATSDR;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;WFD;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;ATSDR;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;PSL;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;WFD;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Chlorella variabilis - cvr;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Chlorella variabilis - cvr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Chlorella variabilis - cvr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Chlorella variabilis - cvr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Chlorella variabilis - cvr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K14497;PP2C;protein phosphatase 2C ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14497;PP2C;protein phosphatase 2C ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14497;PP2C;protein phosphatase 2C ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Chlorella variabilis - cvr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Chlorella variabilis - cvr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Chlorella variabilis - cvr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Chlorella variabilis - cvr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Chlorella variabilis - cvr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Chlorella variabilis - cvr;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Chlorella variabilis - cvr;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Chlorella variabilis - cvr;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Chlorella variabilis - cvr;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Chlorella variabilis - cvr;K13427;NOA1;nitric-oxide synthase, plant ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;synthase
+Chlorella variabilis - cvr;K13427;NOA1;nitric-oxide synthase, plant ;C06681;Polyaromatic;IARC2B;Mitomycin;synthase
+Chlorella variabilis - cvr;K13427;NOA1;nitric-oxide synthase, plant ;C06681;Nitrogen-containing;IARC2B;Mitomycin;synthase
+Chlorella variabilis - cvr;K13427;NOA1;nitric-oxide synthase, plant ;C07569;Aliphatic;IARC2B;Propylthiouracil;synthase
+Chlorella variabilis - cvr;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Chlorella variabilis - cvr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Chlorella variabilis - cvr;K13510;LPCAT1_2;lysophosphatidylcholine acyltransferase / lyso-PAF acetyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Chlorella variabilis - cvr;K13510;LPCAT1_2;lysophosphatidylcholine acyltransferase / lyso-PAF acetyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C00067;Aliphatic;PSL;Formaldehyde;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C00067;Aliphatic;IARC1;Formaldehyde;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C14440;Aliphatic;IARC2B;1,4-Dioxane;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C19191;Aromatic;IARC2B;ortho-Anisidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Nitrogen-containing;PSL;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C14403;Aromatic;IARC1;ortho-Toluidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Nitrogen-containing;IARC1;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Aromatic;PSL;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C14403;Nitrogen-containing;IARC1;ortho-Toluidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Nitrogen-containing;ATSDR;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Aromatic;ATSDR;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C14440;Aliphatic;ATSDR;1,4-Dioxane;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C11195;Polyaromatic;IARC2B;Mitoxantrone;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C19425;Polyaromatic;EPC;Fluoranthene;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C19191;Nitrogen-containing;IARC2B;ortho-Anisidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C19425;Polyaromatic;ATSDR;Fluoranthene;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C00067;Aliphatic;ATSDR;Formaldehyde;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C19425;Polyaromatic;EPA;Fluoranthene;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Aromatic;EPA;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Nitrogen-containing;EPA;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C16444;Aromatic;IARC1;Benzidine;peroxiredoxin 6
+Chlorella variabilis - cvr;K11188;PRDX6;peroxiredoxin 6 ;C19425;Polyaromatic;WFD;Fluoranthene;peroxiredoxin 6
+Chlorella variabilis - cvr;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00774;PARP16;poly [ADP-ribose] polymerase 16 ;C19306;Nitrogen-containing;IARC2B;Trp-P-1;polymerase
+Chlorella variabilis - cvr;K00774;PARP16;poly [ADP-ribose] polymerase 16 ;C14416;Aromatic;IARC2B;Trp-P-2;polymerase
+Chlorella variabilis - cvr;K00774;PARP16;poly [ADP-ribose] polymerase 16 ;C14416;Nitrogen-containing;IARC2B;Trp-P-2;polymerase
+Chlorella variabilis - cvr;K00774;PARP16;poly [ADP-ribose] polymerase 16 ;C19306;Aromatic;IARC2B;Trp-P-1;polymerase
+Chlorella variabilis - cvr;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Chlorella variabilis - cvr;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Chlorella variabilis - cvr;K11414;SIRT4;NAD-dependent protein deacetylase/lipoamidase sirtuin 4 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Chlorella variabilis - cvr;K11414;SIRT4;NAD-dependent protein deacetylase/lipoamidase sirtuin 4 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Chlorella variabilis - cvr;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Chlorella variabilis - cvr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Chlorella variabilis - cvr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Chlorella variabilis - cvr;K15498;PPP6C;serine/threonine-protein phosphatase 6 catalytic subunit ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K15498;PPP6C;serine/threonine-protein phosphatase 6 catalytic subunit ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K15498;PPP6C;serine/threonine-protein phosphatase 6 catalytic subunit ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Aliphatic;WFD;AMPA;aminotransferase
+Chlorella variabilis - cvr;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Nitrogen-containing;WFD;AMPA;aminotransferase
+Chlorella variabilis - cvr;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K15601;KDM3;[histone H3]-dimethyl-L-lysine9 demethylase ;C00067;Aliphatic;PSL;Formaldehyde;demethylase
+Chlorella variabilis - cvr;K15601;KDM3;[histone H3]-dimethyl-L-lysine9 demethylase ;C00067;Aliphatic;IARC1;Formaldehyde;demethylase
+Chlorella variabilis - cvr;K15601;KDM3;[histone H3]-dimethyl-L-lysine9 demethylase ;C00067;Aliphatic;ATSDR;Formaldehyde;demethylase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Chlorella variabilis - cvr;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;ATSDR;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;EPC;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Chlorella variabilis - cvr;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;IARC2B;Dichlorvos;phosphatase
+Chlorella variabilis - cvr;K00025;MDH1;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00025;MDH1;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00025;MDH1;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Chlorinated;IARC2B;Nitrofen;oxidase
+Chlorella variabilis - cvr;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Nitrogen-containing;IARC2B;Nitrofen;oxidase
+Chlorella variabilis - cvr;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Polyaromatic;IARC2B;Nitrofen;oxidase
+Chlorella variabilis - cvr;K16914;RIOX1;protein-L-histidine (3S)-3-hydroxylase / [histone H3]-trimethyl-L-lysine4/36 demethylase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxylase
+Chlorella variabilis - cvr;K16914;RIOX1;protein-L-histidine (3S)-3-hydroxylase / [histone H3]-trimethyl-L-lysine4/36 demethylase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxylase
+Chlorella variabilis - cvr;K16914;RIOX1;protein-L-histidine (3S)-3-hydroxylase / [histone H3]-trimethyl-L-lysine4/36 demethylase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxylase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06354;Polyaromatic;IARC2B;Benzophenone;dioxygenase
+Chlorella variabilis - cvr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Polyaromatic;IARC2B;Mitomycin;dioxygenase
+Chlorella variabilis - cvr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;dioxygenase
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Chlorella variabilis - cvr;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Chlorella variabilis - cvr;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Chlorella variabilis - cvr;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Chlorella variabilis - cvr;K00278;nadB;L-aspartate oxidase ;C19300;Inorganic;IARC2B;Tetranitromethane;oxidase
+Chlorella variabilis - cvr;K00278;nadB;L-aspartate oxidase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;oxidase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Chlorella variabilis - cvr;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Chlorella variabilis - cvr;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Aliphatic;IARC2B;Heptachlor;kinase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Chlorinated;EPA;Heptachlor;kinase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Chlorinated;IARC2B;Heptachlor;kinase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Aliphatic;EPC;Heptachlor;kinase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Chlorinated;ATSDR;Heptachlor;kinase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Chlorinated;EPC;Heptachlor;kinase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Aliphatic;ATSDR;Heptachlor;kinase
+Chlorella variabilis - cvr;K19801;PI4KB;phosphatidylinositol 4-kinase B ;C14185;Aliphatic;EPA;Heptachlor;kinase
+Chlorella variabilis - cvr;K20896;TENA_E;formylaminopyrimidine deformylase / aminopyrimidine aminohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;deformylase
+Chlorella variabilis - cvr;K20896;TENA_E;formylaminopyrimidine deformylase / aminopyrimidine aminohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deformylase
+Chlorella variabilis - cvr;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Chlorella variabilis - cvr;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Chlorella variabilis - cvr;K21286;NTAQ1;protein N-terminal glutamine amidohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidohydrolase
+Chlorella variabilis - cvr;K21286;NTAQ1;protein N-terminal glutamine amidohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;amidohydrolase
+Chlorella variabilis - cvr;K21480;HO;heme oxygenase (biliverdin-producing, ferredoxin) ;C00237;Inorganic;ATSDR;CO;oxygenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Chlorinated;PSL;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Inorganic;WFD;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10928;Aromatic;WFD;Alachlor;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10928;Chlorinated;WFD;Alachlor;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Aliphatic;PSL;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Chlorinated;EPA;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Chlorinated;IARC1;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10928;Chlorinated;EPC;Alachlor;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Inorganic;EPA;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Chlorinated;EPA;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Chlorinated;ATSDR;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Aliphatic;EPC;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10928;Nitrogen-containing;WFD;Alachlor;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Inorganic;ATSDR;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Chlorinated;EPC;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10928;Aromatic;EPC;Alachlor;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Chlorinated;WFD;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C05371;Nitrogen-containing;IARC2B;Microcystin LR;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C05371;Aromatic;IARC2B;Microcystin LR;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Chlorinated;EPC;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Aliphatic;EPA;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11090;Inorganic;EPC;Endosulfan;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C10928;Nitrogen-containing;EPC;Alachlor;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Aliphatic;IARC1;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K21888;DHAR;glutathione dehydrogenase/transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;dehydrogenase
+Chlorella variabilis - cvr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;ATSDR;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;EPC;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;WFD;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;WFD;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;WFD;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;ATSDR;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;ATSDR;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;EPC;Diuron;synthase
+Chlorella variabilis - cvr;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;EPC;Diuron;synthase
+Chlorella variabilis - cvr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K18649;IMPL2;inositol-phosphate phosphatase / L-galactose 1-phosphate phosphatase / histidinol-phosphatase ;C11687;Nitrogen-containing;IARC2B;Aziridine;phosphatase
+Chlorella variabilis - cvr;K18649;IMPL2;inositol-phosphate phosphatase / L-galactose 1-phosphate phosphatase / histidinol-phosphatase ;C11687;Aliphatic;IARC2B;Aziridine;phosphatase
+Chlorella variabilis - cvr;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Halogenated;IARC2B;Dibromoacetonitrile;dehydrogenase
+Chlorella variabilis - cvr;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Nitrogen-containing;IARC2B;Dibromoacetonitrile;dehydrogenase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;EPA;Heptachlor;kinase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;EPC;Heptachlor;kinase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;EPA;Heptachlor;kinase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;EPC;Heptachlor;kinase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;IARC2B;Heptachlor;kinase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;ATSDR;Heptachlor;kinase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;IARC2B;Heptachlor;kinase
+Chlorella variabilis - cvr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;ATSDR;Heptachlor;kinase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C19239;Organosulfur;IARC2B;Ethyl methanesulfonate;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C19239;Aliphatic;IARC2B;Ethyl methanesulfonate;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Chlorella variabilis - cvr;K13998;DHFR-TS;dihydrofolate reductase / thymidylate synthase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Chlorella variabilis - cvr;K22450;SNAT;aralkylamine N-acetyltransferase ;C07591;Aromatic;IARC2A;Phenacetin;acetyltransferase
+Chlorella variabilis - cvr;K22450;SNAT;aralkylamine N-acetyltransferase ;C07591;Nitrogen-containing;IARC2A;Phenacetin;acetyltransferase
+Chlorella variabilis - cvr;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Chlorella variabilis - cvr;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Chlorella variabilis - cvr;K22521;SCO2;protein disulfide-isomerase ;C14462;Chlorinated;CONAMA;3,4-Dichlorophenol;isomerase
+Chlorella variabilis - cvr;K22521;SCO2;protein disulfide-isomerase ;C14462;Aromatic;CONAMA;3,4-Dichlorophenol;isomerase
+Chlorella variabilis - cvr;K22521;SCO2;protein disulfide-isomerase ;C14365;Polyaromatic;IARC1;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Chlorella variabilis - cvr;K22521;SCO2;protein disulfide-isomerase ;C14365;Chlorinated;ATSDR;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Chlorella variabilis - cvr;K22521;SCO2;protein disulfide-isomerase ;C14365;Chlorinated;IARC1;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Chlorella variabilis - cvr;K22521;SCO2;protein disulfide-isomerase ;C14365;Polyaromatic;ATSDR;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C07308;Metal;IARC2B;Cacodylate;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C00014;Nitrogen-containing;PSL;Ammonia;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C07308;Metal;ATSDR;Cacodylate;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C19262;Aliphatic;IARC2B;4-Methylimidazole;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C00014;Nitrogen-containing;ATSDR;Ammonia;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C19262;Nitrogen-containing;IARC2B;4-Methylimidazole;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C07308;Inorganic;ATSDR;Cacodylate;cyclotransferase
+Chlorella variabilis - cvr;K22757;QCT;glutaminyl-peptide cyclotransferase ;C07308;Inorganic;IARC2B;Cacodylate;cyclotransferase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Chlorella variabilis - cvr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Chlorella variabilis - cvr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C05371;Aromatic;IARC2B;Microcystin LR;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Aromatic;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Chlorinated;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Aromatic;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Chlorinated;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C05371;Nitrogen-containing;IARC2B;Microcystin LR;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C05371;Aromatic;IARC2B;Microcystin LR;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Aromatic;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Chlorinated;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Aromatic;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10928;Chlorinated;EPC;Alachlor;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C05371;Nitrogen-containing;IARC2B;Microcystin LR;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11090;Inorganic;WFD;Endosulfan;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Chlorella variabilis - cvr;K23790;GSTP;glutathione S-transferase P ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Chlorella variabilis - cvr;K00261;GLUD1_2;glutamate dehydrogenase (NAD(P)+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00261;GLUD1_2;glutamate dehydrogenase (NAD(P)+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K17991;PXG;peroxygenase ;C18400;Sulfur-containing;ATSDR;Disulfoton;peroxygenase
+Chlorella variabilis - cvr;K17991;PXG;peroxygenase ;C18690;Sulfur-containing;ATSDR;Phorate;peroxygenase
+Chlorella variabilis - cvr;K17991;PXG;peroxygenase ;C18400;Organophosphorus;ATSDR;Disulfoton;peroxygenase
+Chlorella variabilis - cvr;K17991;PXG;peroxygenase ;C18690;Organophosphorus;ATSDR;Phorate;peroxygenase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Chlorella variabilis - cvr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14422;Nitrogen-containing;IARC2A;N-Nitrosodiethylamine;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C07359;Nitrogen-containing;IARC2B;Oxazepam;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14726;Polyaromatic;EPC;2,2',3,3',4',5,5'-Heptachloro-4-biphenylol;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C07359;Polyaromatic;IARC2B;Oxazepam;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14372;Chlorinated;IARC1;2-Hydroxy-2',3',4',5,5'-pentachlorobiphenyl;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C07359;Chlorinated;IARC2B;Oxazepam;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14422;Aliphatic;IARC2A;N-Nitrosodiethylamine;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14372;Polyaromatic;ATSDR;2-Hydroxy-2',3',4',5,5'-pentachlorobiphenyl;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14372;Chlorinated;ATSDR;2-Hydroxy-2',3',4',5,5'-pentachlorobiphenyl;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14372;Polyaromatic;IARC1;2-Hydroxy-2',3',4',5,5'-pentachlorobiphenyl;glucuronosyltransferase
+Chlorella variabilis - cvr;K00699;UGT;glucuronosyltransferase ;C14726;Chlorinated;EPC;2,2',3,3',4',5,5'-Heptachloro-4-biphenylol;glucuronosyltransferase
+Chlorella variabilis - cvr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Chlorella variabilis - cvr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Organometallic;WFD;Phenylmercury acetate;reductase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Aromatic;WFD;Phenylmercury acetate;reductase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Organometallic;EPC;Phenylmercury acetate;reductase
+Chlorella variabilis - cvr;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Aromatic;EPC;Phenylmercury acetate;reductase
+Chlorella variabilis - cvr;K00261;GLUD1_2;glutamate dehydrogenase (NAD(P)+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K00261;GLUD1_2;glutamate dehydrogenase (NAD(P)+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Chlorella variabilis - cvr;K24444;JMJ30;[histone H3]-dimethyl/trimethyl-L-lysine36 demethylase ;C00067;Aliphatic;IARC1;Formaldehyde;demethylase
+Chlorella variabilis - cvr;K24444;JMJ30;[histone H3]-dimethyl/trimethyl-L-lysine36 demethylase ;C00067;Aliphatic;PSL;Formaldehyde;demethylase
+Chlorella variabilis - cvr;K24444;JMJ30;[histone H3]-dimethyl/trimethyl-L-lysine36 demethylase ;C00067;Aliphatic;ATSDR;Formaldehyde;demethylase
+Chlorella variabilis - cvr;K11262;ACACA;acetyl-CoA carboxylase / biotin carboxylase 1 ;C11371;Polyaromatic;IARC2B;Nafenopin;carboxylase
+Cryptococcus gattii - cgi;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Cryptococcus gattii - cgi;K11121;SIR2;NAD-dependent protein deacetylase SIR2 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Cryptococcus gattii - cgi;K21456;GSS;glutathione synthase ;C19302;Aliphatic;IARC2B;Thioacetamide;synthase
+Cryptococcus gattii - cgi;K21456;GSS;glutathione synthase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;synthase
+Cryptococcus gattii - cgi;K21456;GSS;glutathione synthase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;synthase
+Cryptococcus gattii - cgi;K16794;PAFAH1B1;platelet-activating factor acetylhydrolase IB subunit alpha;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acetylhydrolase
+Cryptococcus gattii - cgi;K16794;PAFAH1B1;platelet-activating factor acetylhydrolase IB subunit alpha;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acetylhydrolase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C19262;Aliphatic;IARC2B;4-Methylimidazole;cyclotransferase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C00014;Nitrogen-containing;PSL;Ammonia;cyclotransferase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Inorganic;ATSDR;Cacodylate;cyclotransferase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Metal;ATSDR;Cacodylate;cyclotransferase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Inorganic;IARC2B;Cacodylate;cyclotransferase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C19262;Nitrogen-containing;IARC2B;4-Methylimidazole;cyclotransferase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C00014;Nitrogen-containing;ATSDR;Ammonia;cyclotransferase
+Cryptococcus gattii - cgi;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Metal;IARC2B;Cacodylate;cyclotransferase
+Cryptococcus gattii - cgi;K00643;E2.3.1.37;5-aminolevulinate synthase ;C19233;Aliphatic;IARC2B;1,1-Dimethylhydrazine;synthase
+Cryptococcus gattii - cgi;K00643;E2.3.1.37;5-aminolevulinate synthase ;C19233;Nitrogen-containing;IARC2B;1,1-Dimethylhydrazine;synthase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00965;galT;UDPglucose--hexose-1-phosphate uridylyltransferase ;C19262;Nitrogen-containing;IARC2B;4-Methylimidazole;uridylyltransferase
+Cryptococcus gattii - cgi;K00965;galT;UDPglucose--hexose-1-phosphate uridylyltransferase ;C19262;Aliphatic;IARC2B;4-Methylimidazole;uridylyltransferase
+Cryptococcus gattii - cgi;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Cryptococcus gattii - cgi;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Cryptococcus gattii - cgi;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Cryptococcus gattii - cgi;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Cryptococcus gattii - cgi;K14264;BNA3;kynurenine aminotransferase ;C13672;Aliphatic;WFD;AMPA;aminotransferase
+Cryptococcus gattii - cgi;K14264;BNA3;kynurenine aminotransferase ;C13672;Nitrogen-containing;WFD;AMPA;aminotransferase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Cryptococcus gattii - cgi;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Cryptococcus gattii - cgi;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Cryptococcus gattii - cgi;K00637;SOAT;sterol O-acyltransferase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;acyltransferase
+Cryptococcus gattii - cgi;K00637;SOAT;sterol O-acyltransferase ;C19300;Inorganic;IARC2B;Tetranitromethane;acyltransferase
+Cryptococcus gattii - cgi;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;PSL;Styrene;decarboxylase
+Cryptococcus gattii - cgi;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;CONAMA;Styrene;decarboxylase
+Cryptococcus gattii - cgi;K20039;FDC1;phenacrylate decarboxylase ;C01197;Aromatic;IARC2B;Caffeate;decarboxylase
+Cryptococcus gattii - cgi;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;IARC2A;Styrene;decarboxylase
+Cryptococcus gattii - cgi;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Cryptococcus gattii - cgi;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Cryptococcus gattii - cgi;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Cryptococcus gattii - cgi;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Cryptococcus gattii - cgi;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Cryptococcus gattii - cgi;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Cryptococcus gattii - cgi;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Cryptococcus gattii - cgi;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Cryptococcus gattii - cgi;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Cryptococcus gattii - cgi;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Cryptococcus gattii - cgi;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Aromatic;IARC2A;Pioglitazone;kinase
+Cryptococcus gattii - cgi;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;kinase
+Cryptococcus gattii - cgi;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;kinase
+Cryptococcus gattii - cgi;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Cryptococcus gattii - cgi;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Cryptococcus gattii - cgi;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Cryptococcus gattii - cgi;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Cryptococcus gattii - cgi;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Cryptococcus gattii - cgi;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Cryptococcus gattii - cgi;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Cryptococcus gattii - cgi;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Cryptococcus gattii - cgi;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Cryptococcus gattii - cgi;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Cryptococcus gattii - cgi;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Cryptococcus gattii - cgi;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Inorganic;IARC2B;Tetranitromethane;dehydrogenase
+Cryptococcus gattii - cgi;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;dehydrogenase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K10777;LIG4;DNA ligase 4 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Cryptococcus gattii - cgi;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Cryptococcus gattii - cgi;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Cryptococcus gattii - cgi;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Cryptococcus gattii - cgi;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Cryptococcus gattii - cgi;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Cryptococcus gattii - cgi;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Cryptococcus gattii - cgi;K00877;THI20;hydroxymethylpyrimidine/phosphomethylpyrimidine kinase / thiaminase ;C00014;Nitrogen-containing;PSL;Ammonia;kinase
+Cryptococcus gattii - cgi;K00877;THI20;hydroxymethylpyrimidine/phosphomethylpyrimidine kinase / thiaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;kinase
+Cryptococcus gattii - cgi;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Cryptococcus gattii - cgi;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Cryptococcus gattii - cgi;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Cryptococcus gattii - cgi;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Cryptococcus gattii - cgi;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Cryptococcus gattii - cgi;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Cryptococcus gattii - cgi;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;IARC1;Formaldehyde;synthase
+Cryptococcus gattii - cgi;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;PSL;Formaldehyde;synthase
+Cryptococcus gattii - cgi;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;ATSDR;Formaldehyde;synthase
+Cryptococcus gattii - cgi;K15601;KDM3;[histone H3]-dimethyl-L-lysine9 demethylase ;C00067;Aliphatic;PSL;Formaldehyde;demethylase
+Cryptococcus gattii - cgi;K15601;KDM3;[histone H3]-dimethyl-L-lysine9 demethylase ;C00067;Aliphatic;IARC1;Formaldehyde;demethylase
+Cryptococcus gattii - cgi;K15601;KDM3;[histone H3]-dimethyl-L-lysine9 demethylase ;C00067;Aliphatic;ATSDR;Formaldehyde;demethylase
+Cryptococcus gattii - cgi;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Cryptococcus gattii - cgi;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Cryptococcus gattii - cgi;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Cryptococcus gattii - cgi;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Cryptococcus gattii - cgi;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Cryptococcus gattii - cgi;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Cryptococcus gattii - cgi;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Cryptococcus gattii - cgi;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Cryptococcus gattii - cgi;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Cryptococcus gattii - cgi;K13519;LPT1;lysophospholipid acyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Cryptococcus gattii - cgi;K13519;LPT1;lysophospholipid acyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acyltransferase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Cryptococcus gattii - cgi;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Cryptococcus gattii - cgi;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Cryptococcus gattii - cgi;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Cryptococcus gattii - cgi;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Cryptococcus gattii - cgi;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Cryptococcus gattii - cgi;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Cryptococcus gattii - cgi;K15498;PPP6C;serine/threonine-protein phosphatase 6 catalytic subunit ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Cryptococcus gattii - cgi;K15498;PPP6C;serine/threonine-protein phosphatase 6 catalytic subunit ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Cryptococcus gattii - cgi;K15498;PPP6C;serine/threonine-protein phosphatase 6 catalytic subunit ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Cryptococcus gattii - cgi;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Cryptococcus gattii - cgi;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Cryptococcus gattii - cgi;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Cryptococcus gattii - cgi;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Cryptococcus gattii - cgi;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Cryptococcus gattii - cgi;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Cryptococcus gattii - cgi;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Cryptococcus gattii - cgi;K00327;POR;NADPH-ferrihemoprotein reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Cryptococcus gattii - cgi;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Enterobacter asburiae - eau;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Enterobacter asburiae - eau;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Enterobacter asburiae - eau;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Enterobacter asburiae - eau;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Enterobacter asburiae - eau;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Enterobacter asburiae - eau;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Enterobacter asburiae - eau;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Enterobacter asburiae - eau;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Enterobacter asburiae - eau;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Enterobacter asburiae - eau;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Enterobacter asburiae - eau;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Enterobacter asburiae - eau;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00560;thyA;thymidylate synthase ;C19239;Organosulfur;IARC2B;Ethyl methanesulfonate;synthase
+Enterobacter asburiae - eau;K00560;thyA;thymidylate synthase ;C19239;Aliphatic;IARC2B;Ethyl methanesulfonate;synthase
+Enterobacter asburiae - eau;K18968;adrA;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Enterobacter asburiae - eau;K18968;adrA;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Enterobacter asburiae - eau;K18968;adrA;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Enterobacter asburiae - eau;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Enterobacter asburiae - eau;K13069;E2.7.7.65;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Enterobacter asburiae - eau;K13069;E2.7.7.65;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Enterobacter asburiae - eau;K13069;E2.7.7.65;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Enterobacter asburiae - eau;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Enterobacter asburiae - eau;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K14155;patB;cysteine-S-conjugate beta-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Enterobacter asburiae - eau;K14155;patB;cysteine-S-conjugate beta-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K00845;glk;glucokinase ;C15234;Metal;EPC;Lead nitrate;glucokinase
+Enterobacter asburiae - eau;K00845;glk;glucokinase ;C15234;Inorganic;WFD;Lead nitrate;glucokinase
+Enterobacter asburiae - eau;K00845;glk;glucokinase ;C15234;Nitrogen-containing;EPC;Lead nitrate;glucokinase
+Enterobacter asburiae - eau;K00845;glk;glucokinase ;C15234;Metal;WFD;Lead nitrate;glucokinase
+Enterobacter asburiae - eau;K00845;glk;glucokinase ;C15234;Nitrogen-containing;WFD;Lead nitrate;glucokinase
+Enterobacter asburiae - eau;K00845;glk;glucokinase ;C15234;Inorganic;EPC;Lead nitrate;glucokinase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Enterobacter asburiae - eau;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Enterobacter asburiae - eau;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Enterobacter asburiae - eau;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Enterobacter asburiae - eau;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;IARC2A;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;PSL;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;PSL;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;IARC2A;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K10680;nemA;N-ethylmaleimide reductase ;C16391;Nitrogen-containing;ATSDR;Trinitrotoluene;reductase
+Enterobacter asburiae - eau;K10680;nemA;N-ethylmaleimide reductase ;C16391;Aromatic;ATSDR;Trinitrotoluene;reductase
+Enterobacter asburiae - eau;K00355;NQO1;NAD(P)H dehydrogenase (quinone) ;C10312;Aromatic;IARC2B;Danthron;dehydrogenase
+Enterobacter asburiae - eau;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Enterobacter asburiae - eau;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Enterobacter asburiae - eau;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Enterobacter asburiae - eau;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Enterobacter asburiae - eau;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Enterobacter asburiae - eau;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K00675;nhoA;N-hydroxyarylamine O-acetyltransferase ;C19244;Aliphatic;IARC2B;Glu-P-1;acetyltransferase
+Enterobacter asburiae - eau;K00675;nhoA;N-hydroxyarylamine O-acetyltransferase ;C19244;Nitrogen-containing;IARC2B;Glu-P-1;acetyltransferase
+Enterobacter asburiae - eau;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Enterobacter asburiae - eau;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Enterobacter asburiae - eau;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Enterobacter asburiae - eau;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Enterobacter asburiae - eau;K10778;ada;AraC family transcriptional regulator, regulatory protein of adaptative response / methylated-DNA-[protein]-cysteine methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Enterobacter asburiae - eau;K10778;ada;AraC family transcriptional regulator, regulatory protein of adaptative response / methylated-DNA-[protein]-cysteine methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Enterobacter asburiae - eau;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;ATSDR;Ammonia;kinase
+Enterobacter asburiae - eau;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;PSL;Ammonia;kinase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;ATSDR;Fluoranthene;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;EPA;Acenaphthene;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19304;Sulfur-containing;IARC2B;Thiouracil;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;WFD;Fluoranthene;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPA;Fluoranthene;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19304;Aliphatic;IARC2B;Thiouracil;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;ATSDR;Acenaphthene;chloroperoxidase
+Enterobacter asburiae - eau;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPC;Fluoranthene;chloroperoxidase
+Enterobacter asburiae - eau;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Inorganic;IARC2B;Tetranitromethane;dehydrogenase
+Enterobacter asburiae - eau;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;dehydrogenase
+Enterobacter asburiae - eau;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Enterobacter asburiae - eau;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Enterobacter asburiae - eau;K10680;nemA;N-ethylmaleimide reductase ;C16391;Nitrogen-containing;ATSDR;Trinitrotoluene;reductase
+Enterobacter asburiae - eau;K10680;nemA;N-ethylmaleimide reductase ;C16391;Aromatic;ATSDR;Trinitrotoluene;reductase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;IARC2A;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;PSL;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;PSL;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;IARC2A;Vinyl fluoride;synthase
+Enterobacter asburiae - eau;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Enterobacter asburiae - eau;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Enterobacter asburiae - eau;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Enterobacter asburiae - eau;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00374;narI;nitrate reductase gamma subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00374;narI;nitrate reductase gamma subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00374;narI;nitrate reductase gamma subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00374;narI;nitrate reductase gamma subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Enterobacter asburiae - eau;K00857;tdk;thymidine kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Enterobacter asburiae - eau;K00857;tdk;thymidine kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Enterobacter asburiae - eau;K13497;trpGD;anthranilate synthase/phosphoribosyltransferase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Enterobacter asburiae - eau;K13497;trpGD;anthranilate synthase/phosphoribosyltransferase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Enterobacter asburiae - eau;K11065;tpx;thioredoxin-dependent peroxiredoxin ;C19359;Nitrogen-containing;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Enterobacter asburiae - eau;K11065;tpx;thioredoxin-dependent peroxiredoxin ;C19359;Chlorinated;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Enterobacter asburiae - eau;K00675;nhoA;N-hydroxyarylamine O-acetyltransferase ;C19244;Aliphatic;IARC2B;Glu-P-1;acetyltransferase
+Enterobacter asburiae - eau;K00675;nhoA;N-hydroxyarylamine O-acetyltransferase ;C19244;Nitrogen-containing;IARC2B;Glu-P-1;acetyltransferase
+Enterobacter asburiae - eau;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Enterobacter asburiae - eau;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Enterobacter asburiae - eau;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Enterobacter asburiae - eau;K00331;nuoB;NADH-quinone oxidoreductase subunit B ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K13378;nuoCD;NADH-quinone oxidoreductase subunit C/D ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K13378;nuoCD;NADH-quinone oxidoreductase subunit C/D ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;oxidoreductase
+Enterobacter asburiae - eau;K00336;nuoG;NADH-quinone oxidoreductase subunit G ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K00337;nuoH;NADH-quinone oxidoreductase subunit H ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K00338;nuoI;NADH-quinone oxidoreductase subunit I ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K00339;nuoJ;NADH-quinone oxidoreductase subunit J ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K00341;nuoL;NADH-quinone oxidoreductase subunit L ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K00342;nuoM;NADH-quinone oxidoreductase subunit M ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K00343;nuoN;NADH-quinone oxidoreductase subunit N ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Enterobacter asburiae - eau;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Enterobacter asburiae - eau;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Enterobacter asburiae - eau;K00278;nadB;L-aspartate oxidase ;C19300;Inorganic;IARC2B;Tetranitromethane;oxidase
+Enterobacter asburiae - eau;K00278;nadB;L-aspartate oxidase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;oxidase
+Enterobacter asburiae - eau;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Enterobacter asburiae - eau;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Enterobacter asburiae - eau;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Enterobacter asburiae - eau;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C14399;Chlorinated;IARC2B;1,3-Dichloro-2-propanol;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C14440;Aliphatic;ATSDR;1,4-Dioxane;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C14399;Aliphatic;IARC2B;1,3-Dichloro-2-propanol;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C14440;Aliphatic;IARC2B;1,4-Dioxane;dehydrogenase
+Enterobacter asburiae - eau;K00005;gldA;glycerol dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Enterobacter asburiae - eau;K00299;ssuE;FMN reductase ;C00067;Aliphatic;PSL;Formaldehyde;reductase
+Enterobacter asburiae - eau;K00299;ssuE;FMN reductase ;C00067;Aliphatic;IARC1;Formaldehyde;reductase
+Enterobacter asburiae - eau;K00299;ssuE;FMN reductase ;C00067;Aliphatic;ATSDR;Formaldehyde;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Enterobacter asburiae - eau;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Enterobacter asburiae - eau;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Nitrogen-containing;IARC2A;Captafol;synthase
+Enterobacter asburiae - eau;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Sulfur-containing;IARC2A;Captafol;synthase
+Enterobacter asburiae - eau;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Chlorinated;IARC2A;Captafol;synthase
+Enterobacter asburiae - eau;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Enterobacter asburiae - eau;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Enterobacter asburiae - eau;K10679;nfnB;nitroreductase / dihydropteridine reductase ;C16391;Nitrogen-containing;ATSDR;Trinitrotoluene;nitroreductase
+Enterobacter asburiae - eau;K10679;nfnB;nitroreductase / dihydropteridine reductase ;C16391;Aromatic;ATSDR;Trinitrotoluene;nitroreductase
+Enterobacter asburiae - eau;K00758;deoA;thymidine phosphorylase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;phosphorylase
+Enterobacter asburiae - eau;K00758;deoA;thymidine phosphorylase ;C06681;Polyaromatic;IARC2B;Mitomycin;phosphorylase
+Enterobacter asburiae - eau;K00758;deoA;thymidine phosphorylase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;phosphorylase
+Enterobacter asburiae - eau;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;ATSDR;Ammonia;kinase
+Enterobacter asburiae - eau;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;PSL;Ammonia;kinase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00009;mtlD;mannitol-1-phosphate 5-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Enterobacter asburiae - eau;K00009;mtlD;mannitol-1-phosphate 5-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Enterobacter asburiae - eau;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Enterobacter asburiae - eau;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Enterobacter asburiae - eau;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Enterobacter asburiae - eau;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Enterobacter asburiae - eau;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Enterobacter asburiae - eau;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Enterobacter asburiae - eau;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Enterobacter asburiae - eau;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Enterobacter asburiae - eau;K00363;nirD;nitrite reductase (NADH) small subunit ;C16038;Aromatic;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Enterobacter asburiae - eau;K00363;nirD;nitrite reductase (NADH) small subunit ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Enterobacter asburiae - eau;K00363;nirD;nitrite reductase (NADH) small subunit ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Enterobacter asburiae - eau;K00363;nirD;nitrite reductase (NADH) small subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00363;nirD;nitrite reductase (NADH) small subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00363;nirD;nitrite reductase (NADH) small subunit ;C16038;Nitrogen-containing;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Enterobacter asburiae - eau;K00362;nirB;nitrite reductase (NADH) large subunit ;C16038;Aromatic;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Enterobacter asburiae - eau;K00362;nirB;nitrite reductase (NADH) large subunit ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Enterobacter asburiae - eau;K00362;nirB;nitrite reductase (NADH) large subunit ;C16038;Nitrogen-containing;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Enterobacter asburiae - eau;K00362;nirB;nitrite reductase (NADH) large subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00362;nirB;nitrite reductase (NADH) large subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Enterobacter asburiae - eau;K00362;nirB;nitrite reductase (NADH) large subunit ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Enterobacter asburiae - eau;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Enterobacter asburiae - eau;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Enterobacter asburiae - eau;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Enterobacter asburiae - eau;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Enterobacter asburiae - eau;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Enterobacter asburiae - eau;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Enterobacter asburiae - eau;K00757;udp;uridine phosphorylase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;phosphorylase
+Enterobacter asburiae - eau;K13051;ASRGL1;L-asparaginase / beta-aspartyl-peptidase ;C00014;Nitrogen-containing;PSL;Ammonia;asparaginase
+Enterobacter asburiae - eau;K13051;ASRGL1;L-asparaginase / beta-aspartyl-peptidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;asparaginase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Enterobacter asburiae - eau;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;WFD;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;WFD;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;EPC;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C15584;Aromatic;PSL;Phenol;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;CONAMA;Phenol;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;EPA;Phenol;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;ATSDR;Phenol;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;EPC;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;PSL;Phenol;thioesterase
+Enterobacter asburiae - eau;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;ATSDR;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Enterobacter asburiae - eau;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Enterobacter asburiae - eau;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;EPC;Carbon tetrachloride;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;EPA;Carbon tetrachloride;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C19302;Aliphatic;IARC2B;Thioacetamide;nucleotidase
+Enterobacter asburiae - eau;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;nucleotidase
+Enterobacter asburiae - eau;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;EPC;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;EPC;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;WFD;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;ATSDR;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;WFD;Chlorpyrifos;thioesterase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Enterobacter asburiae - eau;K00287;DHFR;dihydrofolate reductase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Enterobacter asburiae - eau;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Enterobacter asburiae - eau;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Enterobacter asburiae - eau;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Enterobacter asburiae - eau;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Enterobacter asburiae - eau;K00364;guaC;GMP reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Enterobacter asburiae - eau;K00364;guaC;GMP reductase ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00264;GLT1;glutamate synthase (NADH) ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Fusarium graminearum - fgr;K00264;GLT1;glutamate synthase (NADH) ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Fusarium graminearum - fgr;K11187;PRDX5;peroxiredoxin 5 ;C19359;Chlorinated;PSL;Chloramine;peroxiredoxin 5
+Fusarium graminearum - fgr;K11187;PRDX5;peroxiredoxin 5 ;C19359;Nitrogen-containing;PSL;Chloramine;peroxiredoxin 5
+Fusarium graminearum - fgr;K14675;TGL3;TAG lipase / lysophosphatidylethanolamine acyltransferase ;C19309;Aliphatic;IARC2B;Vinyl acetate;lipase
+Fusarium graminearum - fgr;K14675;TGL3;TAG lipase / lysophosphatidylethanolamine acyltransferase ;C14175;Aromatic;EPA;Diethyl phthalate;lipase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Fusarium graminearum - fgr;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Fusarium graminearum - fgr;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Nitrogen-containing;IARC2B;Streptozocin;acetyltransferase
+Fusarium graminearum - fgr;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Aliphatic;IARC2B;Streptozocin;acetyltransferase
+Fusarium graminearum - fgr;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Fusarium graminearum - fgr;K11126;TERT;telomerase reverse transcriptase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;telomerase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Nitrogen-containing;IARC2B;Merphalan;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Nitrogen-containing;IARC2A;Phenacetin;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Aromatic;IARC2B;Merphalan;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Aromatic;IARC2A;Phenacetin;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Chlorinated;IARC2B;Merphalan;dipeptidase
+Fusarium graminearum - fgr;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Fusarium graminearum - fgr;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06354;Polyaromatic;IARC2B;Benzophenone;dioxygenase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Polyaromatic;IARC2B;Mitomycin;dioxygenase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;dioxygenase
+Fusarium graminearum - fgr;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Aromatic;IARC2A;Pioglitazone;kinase
+Fusarium graminearum - fgr;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;kinase
+Fusarium graminearum - fgr;K00914;PIK3C3;phosphatidylinositol 3-kinase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;kinase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;WFD;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;ATSDR;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C02116;Aliphatic;IARC2B;2-Nitropropane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00088;Nitrogen-containing;ATSDR;Nitrite;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC1;Acetaldehyde;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00088;Inorganic;ATSDR;Nitrite;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;WFD;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;PSL;Acetaldehyde;monooxygenase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00637;SOAT;sterol O-acyltransferase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;acyltransferase
+Fusarium graminearum - fgr;K00637;SOAT;sterol O-acyltransferase ;C19300;Inorganic;IARC2B;Tetranitromethane;acyltransferase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;WFD;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;ATSDR;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C02116;Aliphatic;IARC2B;2-Nitropropane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00088;Nitrogen-containing;ATSDR;Nitrite;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC1;Acetaldehyde;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00088;Inorganic;ATSDR;Nitrite;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;WFD;Mercuric chloride;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;monooxygenase
+Fusarium graminearum - fgr;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;PSL;Acetaldehyde;monooxygenase
+Fusarium graminearum - fgr;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K14394;ACP1;low molecular weight phosphotyrosine protein phosphatase ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Organometallic;WFD;Methylmercury chloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Chlorinated;IARC2B;Methylmercury chloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;EPA;Carbon tetrachloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Chlorinated;EPC;Methylmercury chloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;EPC;Carbon tetrachloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Chlorinated;WFD;Methylmercury chloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C19302;Aliphatic;IARC2B;Thioacetamide;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Organometallic;EPC;Methylmercury chloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C11146;Organometallic;IARC2B;Methylmercury chloride;ligase
+Fusarium graminearum - fgr;K11204;GCLC;glutamate--cysteine ligase catalytic subunit ;C19302;Sulfur-containing;IARC2B;Thioacetamide;ligase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Fusarium graminearum - fgr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Fusarium graminearum - fgr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Nitrogen-containing;PSL;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Aliphatic;ATSDR;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Aliphatic;IARC2A;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Aliphatic;PSL;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Aliphatic;EPA;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Nitrogen-containing;ATSDR;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Nitrogen-containing;EPA;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00213;DHCR7;7-dehydrocholesterol reductase ;C14704;Nitrogen-containing;IARC2A;N-Nitrosodimethylamine;reductase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Fusarium graminearum - fgr;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C08469;Polyaromatic;IARC1;Aristolochic acid;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Metal;WFD;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Organometallic;EPC;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Metal;EPC;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Organometallic;WFD;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C08469;Nitrogen-containing;IARC1;Aristolochic acid;phospholipase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Fusarium graminearum - fgr;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Fusarium graminearum - fgr;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Fusarium graminearum - fgr;K17877;NIT-6;nitrite reductase (NAD(P)H) ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K14171;AHP1;alkyl hydroperoxide reductase 1 ;C19359;Nitrogen-containing;PSL;Chloramine;reductase
+Fusarium graminearum - fgr;K14171;AHP1;alkyl hydroperoxide reductase 1 ;C19359;Chlorinated;PSL;Chloramine;reductase
+Fusarium graminearum - fgr;K15440;TAD1;tRNA-specific adenosine deaminase 1 ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Fusarium graminearum - fgr;K15440;TAD1;tRNA-specific adenosine deaminase 1 ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00877;THI20;hydroxymethylpyrimidine/phosphomethylpyrimidine kinase / thiaminase ;C00014;Nitrogen-containing;PSL;Ammonia;kinase
+Fusarium graminearum - fgr;K00877;THI20;hydroxymethylpyrimidine/phosphomethylpyrimidine kinase / thiaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;kinase
+Fusarium graminearum - fgr;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K16794;PAFAH1B1;platelet-activating factor acetylhydrolase IB subunit alpha;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acetylhydrolase
+Fusarium graminearum - fgr;K16794;PAFAH1B1;platelet-activating factor acetylhydrolase IB subunit alpha;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;acetylhydrolase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06354;Polyaromatic;IARC2B;Benzophenone;dioxygenase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Polyaromatic;IARC2B;Mitomycin;dioxygenase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;dioxygenase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00006;GPD1;glycerol-3-phosphate dehydrogenase (NAD+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Fusarium graminearum - fgr;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Fusarium graminearum - fgr;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;PSL;Ammonia;synthetase
+Fusarium graminearum - fgr;K13950;pabAB;para-aminobenzoate synthetase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthetase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K13501;TRP1;anthranilate synthase / indole-3-glycerol phosphate synthase / phosphoribosylanthranilate isomerase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Fusarium graminearum - fgr;K13501;TRP1;anthranilate synthase / indole-3-glycerol phosphate synthase / phosphoribosylanthranilate isomerase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Chlorinated;IARC2B;Nitrofen;oxidase
+Fusarium graminearum - fgr;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Nitrogen-containing;IARC2B;Nitrofen;oxidase
+Fusarium graminearum - fgr;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Polyaromatic;IARC2B;Nitrofen;oxidase
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C08469;Polyaromatic;IARC1;Aristolochic acid;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Metal;WFD;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Organometallic;EPC;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Metal;EPC;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C18149;Organometallic;WFD;Tributyltin oxide;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;phospholipase
+Fusarium graminearum - fgr;K16342;PLA2G4;cytosolic phospholipase A2 ;C08469;Nitrogen-containing;IARC1;Aristolochic acid;phospholipase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;PSL;Formaldehyde;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;WFD;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19594;Aromatic;IARC1;Aflatoxin-M1-8,9-epoxide;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;IARC1;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;CONAMA;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;ATSDR;Formaldehyde;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16756;Aromatic;IARC2B;Aflatoxin M1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14866;Chlorinated;IARC2A;Chloral;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;PSL;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19585;Aromatic;IARC1;Aflatoxin Q1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;PSL;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16038;Aromatic;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;IARC2B;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;EPA;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;EPA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;EPA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;EPC;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;ATSDR;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;PSL;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;IARC1;Formaldehyde;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;ATSDR;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;CONAMA;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Organophosphorus;IARC2B;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;CONAMA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;EPC;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07108;Polyaromatic;IARC1;Tamoxifen;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;IARC1;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;IARC1;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;EPC;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19312;Polyaromatic;ATSDR;Acenaphthene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19595;Aromatic;IARC1;Aflatoxin B1-endo-8,9-epoxide;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06800;Aromatic;IARC1;Aflatoxin B1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;ATSDR;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16453;Nitrogen-containing;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Aromatic;ATSDR;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Organophosphorus;ATSDR;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;EPC;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;CONAMA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16038;Nitrogen-containing;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19312;Polyaromatic;EPA;Acenaphthene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Aromatic;IARC2B;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Nitrogen-containing;IARC2B;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;WFD;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14866;Aliphatic;IARC2A;Chloral;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07108;Nitrogen-containing;IARC1;Tamoxifen;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;EPA;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16453;Aliphatic;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;ATSDR;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16756;Aromatic;IARC1;Aflatoxin M1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Nitrogen-containing;ATSDR;Parathion;reductase
+Fusarium graminearum - fgr;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Nitrogen-containing;IARC2B;Streptozocin;acetyltransferase
+Fusarium graminearum - fgr;K00624;E2.3.1.7;carnitine O-acetyltransferase ;C07313;Aliphatic;IARC2B;Streptozocin;acetyltransferase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00637;SOAT;sterol O-acyltransferase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;acyltransferase
+Fusarium graminearum - fgr;K00637;SOAT;sterol O-acyltransferase ;C19300;Inorganic;IARC2B;Tetranitromethane;acyltransferase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;WFD;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;ATSDR;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;EPC;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;PSL;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K14264;BNA3;kynurenine aminotransferase ;C13672;Aliphatic;WFD;AMPA;aminotransferase
+Fusarium graminearum - fgr;K14264;BNA3;kynurenine aminotransferase ;C13672;Nitrogen-containing;WFD;AMPA;aminotransferase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13333;PLB;lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Aliphatic;IARC2B;Thiouracil;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Chlorinated;EPC;Cypermethrin;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Sulfur-containing;IARC2B;Thiouracil;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Polyaromatic;EPC;Cypermethrin;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Nitrogen-containing;EPC;Cypermethrin;aminotransferase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Fusarium graminearum - fgr;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Fusarium graminearum - fgr;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Fusarium graminearum - fgr;K13996;EPS1;protein disulfide-isomerase ;C14365;Chlorinated;ATSDR;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Fusarium graminearum - fgr;K13996;EPS1;protein disulfide-isomerase ;C14365;Polyaromatic;ATSDR;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Fusarium graminearum - fgr;K13996;EPS1;protein disulfide-isomerase ;C14365;Polyaromatic;IARC1;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Fusarium graminearum - fgr;K13996;EPS1;protein disulfide-isomerase ;C14365;Chlorinated;IARC1;2,3,3',4,5-Pentachlorobiphenyl;isomerase
+Fusarium graminearum - fgr;K13996;EPS1;protein disulfide-isomerase ;C14462;Aromatic;CONAMA;3,4-Dichlorophenol;isomerase
+Fusarium graminearum - fgr;K13996;EPS1;protein disulfide-isomerase ;C14462;Chlorinated;CONAMA;3,4-Dichlorophenol;isomerase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;dioxygenase
+Fusarium graminearum - fgr;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;dioxygenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Inorganic;IARC2B;Cobaltous sulfate;deaminase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Metal;IARC2B;Cobaltous sulfate;deaminase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K14977;ylbA;(S)-ureidoglycine aminohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;aminohydrolase
+Fusarium graminearum - fgr;K14977;ylbA;(S)-ureidoglycine aminohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminohydrolase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10777;LIG4;DNA ligase 4 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Fusarium graminearum - fgr;K00287;DHFR;dihydrofolate reductase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Nitrogen-containing;IARC2B;Merphalan;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Nitrogen-containing;IARC2A;Phenacetin;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Aromatic;IARC2B;Merphalan;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C07591;Aromatic;IARC2A;Phenacetin;dipeptidase
+Fusarium graminearum - fgr;K14213;PEPD;Xaa-Pro dipeptidase ;C19256;Chlorinated;IARC2B;Merphalan;dipeptidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Aliphatic;IARC2B;Thiouracil;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Chlorinated;EPC;Cypermethrin;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C19304;Sulfur-containing;IARC2B;Thiouracil;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Polyaromatic;EPC;Cypermethrin;aminotransferase
+Fusarium graminearum - fgr;K13524;ABAT;4-aminobutyrate aminotransferase / (S)-3-amino-2-methylpropionate transaminase ;C10984;Nitrogen-containing;EPC;Cypermethrin;aminotransferase
+Fusarium graminearum - fgr;K22213;PATG;6-methylsalicylate decarboxylase ;C01467;Aromatic;EPA;3-Cresol;decarboxylase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;PSL;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;EPC;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;EPA;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;EPA;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;EPC;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;ATSDR;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Chlorinated;WFD;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;ATSDR;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;PSL;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K11155;DGAT1;diacylglycerol O-acyltransferase 1 ;C07557;Polyaromatic;WFD;2,3,7,8-Tetrachlorodibenzodioxin;acyltransferase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;PSL;Styrene;decarboxylase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;CONAMA;Styrene;decarboxylase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C01197;Aromatic;IARC2B;Caffeate;decarboxylase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;IARC2A;Styrene;decarboxylase
+Fusarium graminearum - fgr;K21456;GSS;glutathione synthase ;C19302;Aliphatic;IARC2B;Thioacetamide;synthase
+Fusarium graminearum - fgr;K21456;GSS;glutathione synthase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;synthase
+Fusarium graminearum - fgr;K21456;GSS;glutathione synthase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;synthase
+Fusarium graminearum - fgr;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Chlorinated;IARC2A;Nitrogen mustard;dehydrogenase
+Fusarium graminearum - fgr;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;dehydrogenase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Inorganic;IARC2B;Cobaltous sulfate;deaminase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C17383;Metal;IARC2B;Cobaltous sulfate;deaminase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Fusarium graminearum - fgr;K19572;CECR1;adenosine deaminase CECR1 ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dehydratase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dehydratase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dehydratase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dehydratase
+Fusarium graminearum - fgr;K00643;E2.3.1.37;5-aminolevulinate synthase ;C19233;Aliphatic;IARC2B;1,1-Dimethylhydrazine;synthase
+Fusarium graminearum - fgr;K00643;E2.3.1.37;5-aminolevulinate synthase ;C19233;Nitrogen-containing;IARC2B;1,1-Dimethylhydrazine;synthase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00276;AOC3;primary-amine oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K11541;URA2;carbamoyl-phosphate synthase / aspartate carbamoyltransferase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Fusarium graminearum - fgr;K11541;URA2;carbamoyl-phosphate synthase / aspartate carbamoyltransferase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Nitrogen-containing;IARC1;Aristolochic acid;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;PSL;Dibutyl phthalate;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;ATSDR;Dibutyl phthalate;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;EPA;Dibutyl phthalate;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C08469;Polyaromatic;IARC1;Aristolochic acid;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;EPC;Tributyltin oxide;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C19309;Aliphatic;IARC2B;Vinyl acetate;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14214;Aromatic;CONAMA;Dibutyl phthalate;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;WFD;Tributyltin oxide;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Metal;EPC;Tributyltin oxide;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C14175;Aromatic;EPA;Diethyl phthalate;lipase
+Fusarium graminearum - fgr;K14674;TGL4;TAG lipase / steryl ester hydrolase / phospholipase A2 / LPA acyltransferase ;C18149;Organometallic;WFD;Tributyltin oxide;lipase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;PSL;Formaldehyde;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;WFD;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19594;Aromatic;IARC1;Aflatoxin-M1-8,9-epoxide;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;IARC1;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;CONAMA;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;ATSDR;Formaldehyde;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16756;Aromatic;IARC2B;Aflatoxin M1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14866;Chlorinated;IARC2A;Chloral;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;PSL;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19585;Aromatic;IARC1;Aflatoxin Q1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;PSL;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16038;Aromatic;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;IARC2B;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;EPA;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;EPA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;EPA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;EPC;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;ATSDR;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;PSL;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00067;Aliphatic;IARC1;Formaldehyde;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;ATSDR;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;CONAMA;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Organophosphorus;IARC2B;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;CONAMA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;EPC;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07108;Polyaromatic;IARC1;Tamoxifen;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;IARC1;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;IARC1;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Aliphatic;EPC;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19312;Polyaromatic;ATSDR;Acenaphthene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19595;Aromatic;IARC1;Aflatoxin B1-endo-8,9-epoxide;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06800;Aromatic;IARC1;Aflatoxin B1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;ATSDR;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16453;Nitrogen-containing;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Aromatic;ATSDR;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Organophosphorus;ATSDR;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;EPC;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;CONAMA;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16038;Nitrogen-containing;IARC2B;2-Amino-1-methyl-6-phenylimidazo[4,5-b]pyridine;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C19312;Polyaromatic;EPA;Acenaphthene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Aromatic;IARC2B;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Nitrogen-containing;IARC2B;Parathion;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C00829;Polyaromatic;WFD;Naphthalene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C14866;Aliphatic;IARC2A;Chloral;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07108;Nitrogen-containing;IARC1;Tamoxifen;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C07535;Polyaromatic;EPA;Benzo[a]pyrene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16453;Aliphatic;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06790;Chlorinated;ATSDR;Trichloroethene;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C16756;Aromatic;IARC1;Aflatoxin M1;reductase
+Fusarium graminearum - fgr;K14338;cypD_E;cytochrome P450 / NADPH-cytochrome P450 reductase ;C06604;Nitrogen-containing;ATSDR;Parathion;reductase
+Fusarium graminearum - fgr;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;PSL;Catechol;decarboxylase
+Fusarium graminearum - fgr;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;EPC;Catechol;decarboxylase
+Fusarium graminearum - fgr;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;ATSDR;Catechol;decarboxylase
+Fusarium graminearum - fgr;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;IARC2B;Catechol;decarboxylase
+Fusarium graminearum - fgr;K14333;DHBD;2,3-dihydroxybenzoate decarboxylase ;C00090;Aromatic;WFD;Catechol;decarboxylase
+Fusarium graminearum - fgr;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Nitrogen-containing;IARC2A;Captafol;synthase
+Fusarium graminearum - fgr;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Sulfur-containing;IARC2A;Captafol;synthase
+Fusarium graminearum - fgr;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Chlorinated;IARC2A;Captafol;synthase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06354;Polyaromatic;IARC2B;Benzophenone;dioxygenase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Polyaromatic;IARC2B;Mitomycin;dioxygenase
+Fusarium graminearum - fgr;K00463;IDO;indoleamine 2,3-dioxygenase ;C06681;Nitrogen-containing;IARC2B;Mitomycin;dioxygenase
+Fusarium graminearum - fgr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Fusarium graminearum - fgr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Fusarium graminearum - fgr;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Fusarium graminearum - fgr;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Fusarium graminearum - fgr;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Fusarium graminearum - fgr;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Fusarium graminearum - fgr;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C14286;Polyaromatic;IARC2B;Phenolphthalein;reductase
+Fusarium graminearum - fgr;K00327;POR;NADPH-ferrihemoprotein reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00866;CKI1;choline kinase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;kinase
+Fusarium graminearum - fgr;K00866;CKI1;choline kinase ;C07561;Chlorinated;EPC;Carbon tetrachloride;kinase
+Fusarium graminearum - fgr;K00866;CKI1;choline kinase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;kinase
+Fusarium graminearum - fgr;K00866;CKI1;choline kinase ;C07561;Chlorinated;EPA;Carbon tetrachloride;kinase
+Fusarium graminearum - fgr;K00866;CKI1;choline kinase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;kinase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;WFD;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;ATSDR;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;EPC;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K14334;CMLE;carboxy-cis,cis-muconate cyclase ;C01163;Aliphatic;PSL;3-Carboxy-cis,cis-muconate;cyclase
+Fusarium graminearum - fgr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Fusarium graminearum - fgr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Fusarium graminearum - fgr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Fusarium graminearum - fgr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Fusarium graminearum - fgr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Fusarium graminearum - fgr;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Fusarium graminearum - fgr;K00965;galT;UDPglucose--hexose-1-phosphate uridylyltransferase ;C19262;Nitrogen-containing;IARC2B;4-Methylimidazole;uridylyltransferase
+Fusarium graminearum - fgr;K00965;galT;UDPglucose--hexose-1-phosphate uridylyltransferase ;C19262;Aliphatic;IARC2B;4-Methylimidazole;uridylyltransferase
+Fusarium graminearum - fgr;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;CONAMA;2-Chlorophenol;xylosidase
+Fusarium graminearum - fgr;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;ATSDR;2-Chlorophenol;xylosidase
+Fusarium graminearum - fgr;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Aromatic;EPA;2-Chlorophenol;xylosidase
+Fusarium graminearum - fgr;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;xylosidase
+Fusarium graminearum - fgr;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;xylosidase
+Fusarium graminearum - fgr;K15920;XYL4;xylan 1,4-beta-xylosidase ;C14219;Chlorinated;EPA;2-Chlorophenol;xylosidase
+Fusarium graminearum - fgr;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Fusarium graminearum - fgr;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Fusarium graminearum - fgr;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Fusarium graminearum - fgr;K19357;CELB;cellulase ;C01783;Organometallic;WFD;Arylmercury;cellulase
+Fusarium graminearum - fgr;K19357;CELB;cellulase ;C01783;Polyaromatic;EPC;Arylmercury;cellulase
+Fusarium graminearum - fgr;K19357;CELB;cellulase ;C01783;Organometallic;EPC;Arylmercury;cellulase
+Fusarium graminearum - fgr;K19357;CELB;cellulase ;C01783;Polyaromatic;WFD;Arylmercury;cellulase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Fusarium graminearum - fgr;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Fusarium graminearum - fgr;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Fusarium graminearum - fgr;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Fusarium graminearum - fgr;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Fusarium graminearum - fgr;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Fusarium graminearum - fgr;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K11262;ACACA;acetyl-CoA carboxylase / biotin carboxylase 1 ;C11371;Polyaromatic;IARC2B;Nafenopin;carboxylase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Metal;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Metal;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Metal;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;PSL;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Chlorinated;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;WFD;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K10747;LIG1;DNA ligase 1 ;C15233;Inorganic;EPC;Cadmium chloride;ligase
+Fusarium graminearum - fgr;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Aliphatic;IARC2B;Thiouracil;synthase
+Fusarium graminearum - fgr;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;synthase
+Fusarium graminearum - fgr;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Sulfur-containing;IARC2B;Thiouracil;synthase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Fusarium graminearum - fgr;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00026;MDH2;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00026;MDH2;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00026;MDH2;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Fusarium graminearum - fgr;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Fusarium graminearum - fgr;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;IARC1;Formaldehyde;synthase
+Fusarium graminearum - fgr;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;PSL;Formaldehyde;synthase
+Fusarium graminearum - fgr;K17100;DAS;dihydroxyacetone synthase ;C00067;Aliphatic;ATSDR;Formaldehyde;synthase
+Fusarium graminearum - fgr;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Fusarium graminearum - fgr;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Fusarium graminearum - fgr;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Fusarium graminearum - fgr;K17989;SDS;L-serine/L-threonine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Fusarium graminearum - fgr;K17989;SDS;L-serine/L-threonine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Fusarium graminearum - fgr;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Fusarium graminearum - fgr;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Fusarium graminearum - fgr;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Fusarium graminearum - fgr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Fusarium graminearum - fgr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Fusarium graminearum - fgr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Fusarium graminearum - fgr;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Fusarium graminearum - fgr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00618;ARG2;amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Inorganic;IARC2B;Tetranitromethane;dehydrogenase
+Fusarium graminearum - fgr;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;dehydrogenase
+Fusarium graminearum - fgr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Fusarium graminearum - fgr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Fusarium graminearum - fgr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Fusarium graminearum - fgr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Fusarium graminearum - fgr;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;EPA;Heptachlor;kinase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;EPC;Heptachlor;kinase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;EPA;Heptachlor;kinase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;EPC;Heptachlor;kinase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;IARC2B;Heptachlor;kinase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Chlorinated;ATSDR;Heptachlor;kinase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;IARC2B;Heptachlor;kinase
+Fusarium graminearum - fgr;K00888;PI4KA;phosphatidylinositol 4-kinase A ;C14185;Aliphatic;ATSDR;Heptachlor;kinase
+Fusarium graminearum - fgr;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Fusarium graminearum - fgr;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Fusarium graminearum - fgr;K11446;KDM5;[histone H3]-trimethyl-L-lysine4 demethylase ;C00067;Aliphatic;IARC1;Formaldehyde;demethylase
+Fusarium graminearum - fgr;K11446;KDM5;[histone H3]-trimethyl-L-lysine4 demethylase ;C00067;Aliphatic;ATSDR;Formaldehyde;demethylase
+Fusarium graminearum - fgr;K11446;KDM5;[histone H3]-trimethyl-L-lysine4 demethylase ;C00067;Aliphatic;PSL;Formaldehyde;demethylase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Polyaromatic;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Nitrogen-containing;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Organophosphorus;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Aliphatic;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Organophosphorus;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Nitrogen-containing;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Aromatic;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Sulfur-containing;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Sulfur-containing;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Nitrogen-containing;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C19306;Nitrogen-containing;IARC2B;Trp-P-1;polymerase
+Fusarium graminearum - fgr;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C14416;Nitrogen-containing;IARC2B;Trp-P-2;polymerase
+Fusarium graminearum - fgr;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C19306;Aromatic;IARC2B;Trp-P-1;polymerase
+Fusarium graminearum - fgr;K10798;PARP2_3_4;poly [ADP-ribose] polymerase 2/3/4 ;C14416;Aromatic;IARC2B;Trp-P-2;polymerase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;PSL;Styrene;decarboxylase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;CONAMA;Styrene;decarboxylase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C01197;Aromatic;IARC2B;Caffeate;decarboxylase
+Fusarium graminearum - fgr;K20039;FDC1;phenacrylate decarboxylase ;C07083;Aromatic;IARC2A;Styrene;decarboxylase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K20247;EGT2;hercynylcysteine S-oxide lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Fusarium graminearum - fgr;K20247;EGT2;hercynylcysteine S-oxide lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Fusarium graminearum - fgr;K15877;CYP55;fungal nitric oxide reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Fusarium graminearum - fgr;K15877;CYP55;fungal nitric oxide reductase ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Fusarium graminearum - fgr;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;ATSDR;Butylbenzyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;PSL;Catechol;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;IARC2B;Catechol;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;EPA;Butylbenzyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;PSL;Dibutyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14211;Polyaromatic;PSL;Butylbenzyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;ATSDR;Catechol;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;CONAMA;Dibutyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;WFD;Catechol;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;EPA;Dibutyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14227;Aromatic;PSL;Di-n-octyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C00090;Aromatic;EPC;Catechol;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14205;Aromatic;EPC;4-tert-Octylphenol;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14214;Aromatic;ATSDR;Dibutyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14227;Aromatic;EPA;Di-n-octyl phthalate;methyltransferase
+Fusarium graminearum - fgr;K00545;COMT;catechol O-methyltransferase ;C14205;Aromatic;WFD;4-tert-Octylphenol;methyltransferase
+Fusarium graminearum - fgr;K20498;DSD1;D-serine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Fusarium graminearum - fgr;K20498;DSD1;D-serine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Aliphatic;IARC2B;Heptachlor;kinase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Chlorinated;EPA;Heptachlor;kinase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Chlorinated;EPC;Heptachlor;kinase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Aliphatic;EPA;Heptachlor;kinase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Aliphatic;ATSDR;Heptachlor;kinase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Chlorinated;ATSDR;Heptachlor;kinase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Chlorinated;IARC2B;Heptachlor;kinase
+Fusarium graminearum - fgr;K13711;PI4K2;phosphatidylinositol 4-kinase type 2 ;C14185;Aliphatic;EPC;Heptachlor;kinase
+Fusarium graminearum - fgr;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Halogenated;IARC2B;Dibromoacetonitrile;dehydrogenase
+Fusarium graminearum - fgr;K00106;XDH;xanthine dehydrogenase/oxidase ;C19396;Nitrogen-containing;IARC2B;Dibromoacetonitrile;dehydrogenase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Polyaromatic;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Nitrogen-containing;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Organophosphorus;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Aliphatic;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Organophosphorus;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Nitrogen-containing;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Aromatic;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Sulfur-containing;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Sulfur-containing;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Nitrogen-containing;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Polyaromatic;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Nitrogen-containing;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Organophosphorus;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Aliphatic;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Organophosphorus;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Nitrogen-containing;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Aromatic;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Sulfur-containing;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Sulfur-containing;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Nitrogen-containing;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K14541;DUR1;urea carboxylase / allophanate hydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;carboxylase
+Fusarium graminearum - fgr;K14541;DUR1;urea carboxylase / allophanate hydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;carboxylase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Nitrogen-containing;WFD;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Aromatic;WFD;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Aromatic;ATSDR;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Chlorinated;ATSDR;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Aromatic;EPC;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Chlorinated;WFD;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Chlorinated;EPC;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Nitrogen-containing;ATSDR;Diuron;desaturase
+Fusarium graminearum - fgr;K22993;K22993;bifunctional Delta-12/omega-3 fatty acid desaturase ;C18428;Nitrogen-containing;EPC;Diuron;desaturase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C00014;Nitrogen-containing;PSL;Ammonia;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C04317;Nitrogen-containing;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C14430;Organophosphorus;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C04317;Organophosphorus;PSL;1-Organyl-2-lyso-sn-glycero-3-phosphocholine;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C14430;Chlorinated;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C14430;Organophosphorus;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C14430;Chlorinated;ATSDR;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C14430;Chlorinated;EPC;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K13278;ASPG;60kDa lysophospholipase ;C14430;Organophosphorus;IARC2B;Dichlorvos;lysophospholipase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Polyaromatic;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Nitrogen-containing;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Organophosphorus;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C19233;Aliphatic;IARC2B;1,1-Dimethylhydrazine;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Organophosphorus;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Aromatic;EPA;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C07108;Nitrogen-containing;IARC1;Tamoxifen;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Aromatic;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18690;Sulfur-containing;ATSDR;Phorate;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C18400;Sulfur-containing;ATSDR;Disulfoton;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C02846;Nitrogen-containing;ATSDR;N,N-Dimethylaniline;monooxygenase
+Fusarium graminearum - fgr;K00485;FMO;dimethylaniline monooxygenase (N-oxide forming) / hypotaurine monooxygenase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;monooxygenase
+Fusarium graminearum - fgr;K10775;PAL;phenylalanine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Fusarium graminearum - fgr;K10775;PAL;phenylalanine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Fusarium graminearum - fgr;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Inorganic;IARC2B;Tetranitromethane;monooxygenase
+Fusarium graminearum - fgr;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;monooxygenase
+Fusarium graminearum - fgr;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Inorganic;IARC2B;Tetranitromethane;monooxygenase
+Fusarium graminearum - fgr;K00467;E1.13.12.4;lactate 2-monooxygenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;monooxygenase
+Fusarium graminearum - fgr;K22213;PATG;6-methylsalicylate decarboxylase ;C01467;Aromatic;EPA;3-Cresol;decarboxylase
+Fusarium graminearum - fgr;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidase
+Fusarium graminearum - fgr;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;PSL;Ammonia;amidase
+Fusarium graminearum - fgr;K19823;NAO;nitroalkane oxidase ;C00084;Aliphatic;PSL;Acetaldehyde;oxidase
+Fusarium graminearum - fgr;K19823;NAO;nitroalkane oxidase ;C00088;Nitrogen-containing;ATSDR;Nitrite;oxidase
+Fusarium graminearum - fgr;K19823;NAO;nitroalkane oxidase ;C00084;Aliphatic;IARC2B;Acetaldehyde;oxidase
+Fusarium graminearum - fgr;K19823;NAO;nitroalkane oxidase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;oxidase
+Fusarium graminearum - fgr;K19823;NAO;nitroalkane oxidase ;C02116;Aliphatic;IARC2B;2-Nitropropane;oxidase
+Fusarium graminearum - fgr;K19823;NAO;nitroalkane oxidase ;C00084;Aliphatic;IARC1;Acetaldehyde;oxidase
+Fusarium graminearum - fgr;K19823;NAO;nitroalkane oxidase ;C00088;Inorganic;ATSDR;Nitrite;oxidase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00273;DAO;D-amino-acid oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K23856;GPX;peroxiredoxin ;C19359;Nitrogen-containing;PSL;Chloramine;peroxiredoxin
+Fusarium graminearum - fgr;K23856;GPX;peroxiredoxin ;C19359;Chlorinated;PSL;Chloramine;peroxiredoxin
+Fusarium graminearum - fgr;K22911;TH2;thiamine phosphate phosphatase / amino-HMP aminohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;phosphatase
+Fusarium graminearum - fgr;K22911;TH2;thiamine phosphate phosphatase / amino-HMP aminohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;phosphatase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Fusarium graminearum - fgr;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K25880;LADA;L-arabinitol 4-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;PSL;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C19256;Aromatic;IARC2B;Merphalan;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C19256;Nitrogen-containing;IARC2B;Merphalan;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;EPC;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;EPC;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;ATSDR;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C16453;Nitrogen-containing;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C16453;Aliphatic;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;PSL;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;ATSDR;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;IARC2B;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C19256;Chlorinated;IARC2B;Merphalan;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;WFD;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;WFD;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Fusarium graminearum - fgr;K11414;SIRT4;NAD-dependent protein deacetylase/lipoamidase sirtuin 4 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Fusarium graminearum - fgr;K11414;SIRT4;NAD-dependent protein deacetylase/lipoamidase sirtuin 4 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C05371;Nitrogen-containing;IARC2B;Microcystin LR;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C05371;Aromatic;IARC2B;Microcystin LR;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K13299;GSTK1;glutathione S-transferase kappa 1 ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K14263;BNA7;kynurenine formamidase ;C14520;Nitrogen-containing;EPC;Chlorpyrifos-methyl;formamidase
+Fusarium graminearum - fgr;K14263;BNA7;kynurenine formamidase ;C14520;Organophosphorus;EPC;Chlorpyrifos-methyl;formamidase
+Fusarium graminearum - fgr;K14263;BNA7;kynurenine formamidase ;C14520;Sulfur-containing;EPC;Chlorpyrifos-methyl;formamidase
+Fusarium graminearum - fgr;K14263;BNA7;kynurenine formamidase ;C14403;Nitrogen-containing;IARC1;ortho-Toluidine;formamidase
+Fusarium graminearum - fgr;K14263;BNA7;kynurenine formamidase ;C14520;Chlorinated;EPC;Chlorpyrifos-methyl;formamidase
+Fusarium graminearum - fgr;K14263;BNA7;kynurenine formamidase ;C14403;Aromatic;IARC1;ortho-Toluidine;formamidase
+Fusarium graminearum - fgr;K20498;DSD1;D-serine ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Fusarium graminearum - fgr;K20498;DSD1;D-serine ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Fusarium graminearum - fgr;K21552;HOL;methyl halide transferase ;C19446;Chlorinated;ATSDR;Methyl chloride;transferase
+Fusarium graminearum - fgr;K21552;HOL;methyl halide transferase ;C18447;Halogenated;EPA;Methyl bromide;transferase
+Fusarium graminearum - fgr;K21552;HOL;methyl halide transferase ;C19446;Aliphatic;ATSDR;Methyl chloride;transferase
+Fusarium graminearum - fgr;K21552;HOL;methyl halide transferase ;C18447;Aliphatic;EPA;Methyl bromide;transferase
+Fusarium graminearum - fgr;K21552;HOL;methyl halide transferase ;C19446;Aliphatic;EPA;Methyl chloride;transferase
+Fusarium graminearum - fgr;K21552;HOL;methyl halide transferase ;C19446;Chlorinated;EPA;Methyl chloride;transferase
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Fusarium graminearum - fgr;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K17066;MOX;alcohol oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;PSL;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C19256;Aromatic;IARC2B;Merphalan;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C19256;Nitrogen-containing;IARC2B;Merphalan;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;EPC;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;EPC;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;ATSDR;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C16453;Nitrogen-containing;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C16453;Aliphatic;IARC1;4-(N-Nitrosomethylamino)-1-(3-pyridyl)-1-butanone;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;PSL;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;ATSDR;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;IARC2B;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C19256;Chlorinated;IARC2B;Merphalan;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C00090;Aromatic;WFD;Catechol;dehydrogenase
+Fusarium graminearum - fgr;K00078;DHDH;dihydrodiol dehydrogenase / D-xylose 1-dehydrogenase (NADP) ;C03012;Polyaromatic;WFD;Naphthalene-1,2-diol;dehydrogenase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00306;PIPOX;sarcosine oxidase / L-pipecolate oxidase ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;WFD;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;IARC2B;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Chlorinated;CONAMA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;ATSDR;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C01197;Aromatic;IARC2B;Caffeate;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;PSL;Catechol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;ATSDR;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C14219;Aromatic;EPA;2-Chlorophenol;tyrosinase
+Fusarium graminearum - fgr;K00505;TYR;tyrosinase ;C00090;Aromatic;EPC;Catechol;tyrosinase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C07561;Chlorinated;EPA;Carbon tetrachloride;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C07561;Chlorinated;EPC;Carbon tetrachloride;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;phosphatase
+Fusarium graminearum - fgr;K19283;ACPP;prostatic acid phosphatase ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C19262;Aliphatic;IARC2B;4-Methylimidazole;cyclotransferase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C00014;Nitrogen-containing;PSL;Ammonia;cyclotransferase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Inorganic;ATSDR;Cacodylate;cyclotransferase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Metal;ATSDR;Cacodylate;cyclotransferase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Inorganic;IARC2B;Cacodylate;cyclotransferase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C19262;Nitrogen-containing;IARC2B;4-Methylimidazole;cyclotransferase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C00014;Nitrogen-containing;ATSDR;Ammonia;cyclotransferase
+Fusarium graminearum - fgr;K00683;QPCT;glutaminyl-peptide cyclotransferase ;C07308;Metal;IARC2B;Cacodylate;cyclotransferase
+Fusarium graminearum - fgr;K11415;SIRT5;NAD-dependent protein deacetylase sirtuin 5 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Fusarium graminearum - fgr;K11415;SIRT5;NAD-dependent protein deacetylase sirtuin 5 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Fusarium graminearum - fgr;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Fusarium graminearum - fgr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Fusarium graminearum - fgr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Fusarium graminearum - fgr;K00274;MAO;monoamine oxidase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;oxidase
+Fusarium graminearum - fgr;K00274;MAO;monoamine oxidase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;oxidase
+Fusarium graminearum - fgr;K00274;MAO;monoamine oxidase ;C07675;Aromatic;IARC2A;Pioglitazone;oxidase
+Fusarium graminearum - fgr;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Fusarium graminearum - fgr;K00274;MAO;monoamine oxidase ;C19263;Aliphatic;IARC2B;Methyl isobutyl ketone;oxidase
+Fusarium graminearum - fgr;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Fusarium graminearum - fgr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Fusarium graminearum - fgr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Fusarium graminearum - fgr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Fusarium graminearum - fgr;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Fusarium graminearum - fgr;K10675;E4.2.1.66;cyanide hydratase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;hydratase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Fusarium graminearum - fgr;K00560;thyA;thymidylate synthase ;C19239;Organosulfur;IARC2B;Ethyl methanesulfonate;synthase
+Fusarium graminearum - fgr;K00560;thyA;thymidylate synthase ;C19239;Aliphatic;IARC2B;Ethyl methanesulfonate;synthase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dehydratase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dehydratase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dehydratase
+Fusarium graminearum - fgr;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dehydratase
+Nannochloropsis gaditana - ngd;K21456;GSS;glutathione synthase ;C19302;Aliphatic;IARC2B;Thioacetamide;synthase
+Nannochloropsis gaditana - ngd;K21456;GSS;glutathione synthase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;synthase
+Nannochloropsis gaditana - ngd;K21456;GSS;glutathione synthase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;synthase
+Nannochloropsis gaditana - ngd;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Aliphatic;WFD;AMPA;aminotransferase
+Nannochloropsis gaditana - ngd;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Nitrogen-containing;WFD;AMPA;aminotransferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Nannochloropsis gaditana - ngd;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Nannochloropsis gaditana - ngd;K00560;thyA;thymidylate synthase ;C19239;Organosulfur;IARC2B;Ethyl methanesulfonate;synthase
+Nannochloropsis gaditana - ngd;K00560;thyA;thymidylate synthase ;C19239;Aliphatic;IARC2B;Ethyl methanesulfonate;synthase
+Nannochloropsis gaditana - ngd;K14662;NTAN1;protein N-terminal asparagine amidohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidohydrolase
+Nannochloropsis gaditana - ngd;K14662;NTAN1;protein N-terminal asparagine amidohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;amidohydrolase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Nannochloropsis gaditana - ngd;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;dioxygenase
+Nannochloropsis gaditana - ngd;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;dioxygenase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;EPA;4-Nitrophenol;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;ATSDR;Dichlorvos;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;EPC;Dichlorvos;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;ATSDR;Dichlorvos;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;IARC2B;Dichlorvos;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;ATSDR;4-Nitrophenol;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Chlorinated;EPC;Dichlorvos;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Aromatic;ATSDR;4-Nitrophenol;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C00870;Nitrogen-containing;EPA;4-Nitrophenol;phosphatase
+Nannochloropsis gaditana - ngd;K14379;ACP5;tartrate-resistant acid phosphatase type 5 ;C14430;Organophosphorus;IARC2B;Dichlorvos;phosphatase
+Nannochloropsis gaditana - ngd;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Aliphatic;WFD;AMPA;aminotransferase
+Nannochloropsis gaditana - ngd;K00825;AADAT;kynurenine/2-aminoadipate aminotransferase ;C13672;Nitrogen-containing;WFD;AMPA;aminotransferase
+Nannochloropsis gaditana - ngd;K11415;SIRT5;NAD-dependent protein deacetylase sirtuin 5 ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Nannochloropsis gaditana - ngd;K11415;SIRT5;NAD-dependent protein deacetylase sirtuin 5 ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Nannochloropsis gaditana - ngd;K21286;NTAQ1;protein N-terminal glutamine amidohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidohydrolase
+Nannochloropsis gaditana - ngd;K21286;NTAQ1;protein N-terminal glutamine amidohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;amidohydrolase
+Nannochloropsis gaditana - ngd;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;kinase
+Nannochloropsis gaditana - ngd;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;kinase
+Nannochloropsis gaditana - ngd;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;EPA;Carbon tetrachloride;kinase
+Nannochloropsis gaditana - ngd;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;EPC;Carbon tetrachloride;kinase
+Nannochloropsis gaditana - ngd;K14156;CHK;choline/ethanolamine kinase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;kinase
+Nannochloropsis gaditana - ngd;K00654;SPT;serine palmitoyltransferase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Nannochloropsis gaditana - ngd;K00654;SPT;serine palmitoyltransferase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;palmitoyltransferase
+Nannochloropsis gaditana - ngd;K00654;SPT;serine palmitoyltransferase ;C01576;Polyaromatic;IARC1;Etoposide;palmitoyltransferase
+Nannochloropsis gaditana - ngd;K00654;SPT;serine palmitoyltransferase ;C07675;Aromatic;IARC2A;Pioglitazone;palmitoyltransferase
+Nannochloropsis gaditana - ngd;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Nannochloropsis gaditana - ngd;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Nannochloropsis gaditana - ngd;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Nannochloropsis gaditana - ngd;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Chlorinated;IARC2B;Nitrofen;oxidase
+Nannochloropsis gaditana - ngd;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Nitrogen-containing;IARC2B;Nitrofen;oxidase
+Nannochloropsis gaditana - ngd;K00231;PPOX;protoporphyrinogen/coproporphyrinogen III oxidase ;C11065;Polyaromatic;IARC2B;Nitrofen;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;WFD;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;WFD;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;ATSDR;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Halogenated;EPC;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00232;E1.3.3.6;acyl-CoA oxidase ;C18142;Sulfur-containing;EPC;Perfluorooctanesulfonic acid;oxidase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;ATSDR;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Chlorinated;WFD;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00008;SORD;L-iditol 2-dehydrogenase ;C13377;Metal;WFD;Mercuric chloride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Nannochloropsis gaditana - ngd;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Nannochloropsis gaditana - ngd;K00816;CCBL;kynurenine---oxoglutarate transaminase / cysteine-S-conjugate beta-lyase / glutamine---phenylpyruvate transaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;transaminase
+Nannochloropsis gaditana - ngd;K00816;CCBL;kynurenine---oxoglutarate transaminase / cysteine-S-conjugate beta-lyase / glutamine---phenylpyruvate transaminase ;C13672;Nitrogen-containing;WFD;AMPA;transaminase
+Nannochloropsis gaditana - ngd;K00816;CCBL;kynurenine---oxoglutarate transaminase / cysteine-S-conjugate beta-lyase / glutamine---phenylpyruvate transaminase ;C13672;Aliphatic;WFD;AMPA;transaminase
+Nannochloropsis gaditana - ngd;K00816;CCBL;kynurenine---oxoglutarate transaminase / cysteine-S-conjugate beta-lyase / glutamine---phenylpyruvate transaminase ;C00014;Nitrogen-containing;PSL;Ammonia;transaminase
+Nannochloropsis gaditana - ngd;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Aliphatic;IARC2B;Thiouracil;synthase
+Nannochloropsis gaditana - ngd;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;synthase
+Nannochloropsis gaditana - ngd;K16330;K16330;pseudouridylate synthase / pseudouridine kinase ;C19304;Sulfur-containing;IARC2B;Thiouracil;synthase
+Nannochloropsis gaditana - ngd;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Sulfur-containing;IARC2B;Propylthiouracil;reductase
+Nannochloropsis gaditana - ngd;K00326;CYB5R;cytochrome-b5 reductase ;C07569;Aliphatic;IARC2B;Propylthiouracil;reductase
+Nannochloropsis gaditana - ngd;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Nannochloropsis gaditana - ngd;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Nannochloropsis gaditana - ngd;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Nannochloropsis gaditana - ngd;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;IARC2A;Vinyl fluoride;synthase
+Nannochloropsis gaditana - ngd;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;PSL;Vinyl fluoride;synthase
+Nannochloropsis gaditana - ngd;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;PSL;Vinyl fluoride;synthase
+Nannochloropsis gaditana - ngd;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;IARC2A;Vinyl fluoride;synthase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Organometallic;WFD;Phenylmercury acetate;reductase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Aromatic;WFD;Phenylmercury acetate;reductase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Organometallic;EPC;Phenylmercury acetate;reductase
+Nannochloropsis gaditana - ngd;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Aromatic;EPC;Phenylmercury acetate;reductase
+Nannochloropsis gaditana - ngd;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Nannochloropsis gaditana - ngd;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Pseudomonas aeruginosa - pae;K00560;thyA;thymidylate synthase ;C19239;Organosulfur;IARC2B;Ethyl methanesulfonate;synthase
+Pseudomonas aeruginosa - pae;K00560;thyA;thymidylate synthase ;C19239;Aliphatic;IARC2B;Ethyl methanesulfonate;synthase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K00287;DHFR;dihydrofolate reductase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Pseudomonas aeruginosa - pae;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Pseudomonas aeruginosa - pae;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Nitrogen-containing;IARC2A;Captafol;synthase
+Pseudomonas aeruginosa - pae;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Sulfur-containing;IARC2A;Captafol;synthase
+Pseudomonas aeruginosa - pae;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Chlorinated;IARC2A;Captafol;synthase
+Pseudomonas aeruginosa - pae;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Pseudomonas aeruginosa - pae;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Pseudomonas aeruginosa - pae;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Pseudomonas aeruginosa - pae;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Pseudomonas aeruginosa - pae;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Pseudomonas aeruginosa - pae;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Pseudomonas aeruginosa - pae;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Pseudomonas aeruginosa - pae;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Pseudomonas aeruginosa - pae;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Pseudomonas aeruginosa - pae;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00019;BDH1;3-hydroxybutyrate dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Pseudomonas aeruginosa - pae;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Pseudomonas aeruginosa - pae;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Pseudomonas aeruginosa - pae;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Pseudomonas aeruginosa - pae;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Pseudomonas aeruginosa - pae;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00528;fpr;ferredoxin/flavodoxin---NADP+ reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K19744;dauB;L-arginine dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K19744;dauB;L-arginine dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00263;E1.4.1.9;leucine dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00263;E1.4.1.9;leucine dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00263;E1.4.1.9;leucine dehydrogenase ;C19263;Aliphatic;IARC2B;Methyl isobutyl ketone;dehydrogenase
+Pseudomonas aeruginosa - pae;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Pseudomonas aeruginosa - pae;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Pseudomonas aeruginosa - pae;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Pseudomonas aeruginosa - pae;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Pseudomonas aeruginosa - pae;K00299;ssuE;FMN reductase ;C00067;Aliphatic;PSL;Formaldehyde;reductase
+Pseudomonas aeruginosa - pae;K00299;ssuE;FMN reductase ;C00067;Aliphatic;IARC1;Formaldehyde;reductase
+Pseudomonas aeruginosa - pae;K00299;ssuE;FMN reductase ;C00067;Aliphatic;ATSDR;Formaldehyde;reductase
+Pseudomonas aeruginosa - pae;K00299;ssuE;FMN reductase ;C00067;Aliphatic;PSL;Formaldehyde;reductase
+Pseudomonas aeruginosa - pae;K00299;ssuE;FMN reductase ;C00067;Aliphatic;IARC1;Formaldehyde;reductase
+Pseudomonas aeruginosa - pae;K00299;ssuE;FMN reductase ;C00067;Aliphatic;ATSDR;Formaldehyde;reductase
+Pseudomonas aeruginosa - pae;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Pseudomonas aeruginosa - pae;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Pseudomonas aeruginosa - pae;K00278;nadB;L-aspartate oxidase ;C19300;Inorganic;IARC2B;Tetranitromethane;oxidase
+Pseudomonas aeruginosa - pae;K00278;nadB;L-aspartate oxidase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;oxidase
+Pseudomonas aeruginosa - pae;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Pseudomonas aeruginosa - pae;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;dioxygenase
+Pseudomonas aeruginosa - pae;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;dioxygenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;PSL;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;EPC;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;WFD;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C01163;Aliphatic;ATSDR;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00449;pcaH;protocatechuate 3,4-dioxygenase, beta subunit ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;ATSDR;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;WFD;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;EPC;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dioxygenase
+Pseudomonas aeruginosa - pae;K00448;pcaG;protocatechuate 3,4-dioxygenase, alpha subunit ;C01163;Aliphatic;PSL;3-Carboxy-cis,cis-muconate;dioxygenase
+Pseudomonas aeruginosa - pae;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Pseudomonas aeruginosa - pae;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Pseudomonas aeruginosa - pae;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;monooxygenase
+Pseudomonas aeruginosa - pae;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;monooxygenase
+Pseudomonas aeruginosa - pae;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;monooxygenase
+Pseudomonas aeruginosa - pae;K00481;pobA;p-hydroxybenzoate 3-monooxygenase ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;monooxygenase
+Pseudomonas aeruginosa - pae;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;ATSDR;Ammonia;kinase
+Pseudomonas aeruginosa - pae;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;PSL;Ammonia;kinase
+Pseudomonas aeruginosa - pae;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Pseudomonas aeruginosa - pae;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Pseudomonas aeruginosa - pae;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Chlorinated;IARC2A;Nitrogen mustard;dehydrogenase
+Pseudomonas aeruginosa - pae;K00130;betB;betaine-aldehyde dehydrogenase ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;dehydrogenase
+Pseudomonas aeruginosa - pae;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00303;soxB;sarcosine oxidase, subunit beta ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00303;soxB;sarcosine oxidase, subunit beta ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00303;soxB;sarcosine oxidase, subunit beta ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00304;soxD;sarcosine oxidase, subunit delta ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00304;soxD;sarcosine oxidase, subunit delta ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00304;soxD;sarcosine oxidase, subunit delta ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00302;soxA;sarcosine oxidase, subunit alpha ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00302;soxA;sarcosine oxidase, subunit alpha ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00302;soxA;sarcosine oxidase, subunit alpha ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00305;soxG;sarcosine oxidase, subunit gamma ;C00067;Aliphatic;PSL;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00305;soxG;sarcosine oxidase, subunit gamma ;C00067;Aliphatic;IARC1;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00305;soxG;sarcosine oxidase, subunit gamma ;C00067;Aliphatic;ATSDR;Formaldehyde;oxidase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;IARC2A;Vinyl fluoride;synthase
+Pseudomonas aeruginosa - pae;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;PSL;Vinyl fluoride;synthase
+Pseudomonas aeruginosa - pae;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Halogenated;PSL;Vinyl fluoride;synthase
+Pseudomonas aeruginosa - pae;K00574;cfa;cyclopropane-fatty-acyl-phospholipid synthase ;C19185;Aliphatic;IARC2A;Vinyl fluoride;synthase
+Pseudomonas aeruginosa - pae;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Pseudomonas aeruginosa - pae;K00567;ogt;methylated-DNA-[protein]-cysteine S-methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Pseudomonas aeruginosa - pae;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Pseudomonas aeruginosa - pae;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Pseudomonas aeruginosa - pae;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Pseudomonas aeruginosa - pae;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Pseudomonas aeruginosa - pae;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Pseudomonas aeruginosa - pae;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Pseudomonas aeruginosa - pae;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Pseudomonas aeruginosa - pae;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Pseudomonas aeruginosa - pae;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Pseudomonas aeruginosa - pae;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00372;nasC;assimilatory nitrate reductase catalytic subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;EPC;Lead nitrate;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;EPC;Lead nitrate;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C06956;Aliphatic;IARC2B;Digoxin;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C07115;Chlorinated;IARC2A;Nitrogen mustard;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;EPC;Lead nitrate;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C15234;Inorganic;WFD;Lead nitrate;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C15234;Nitrogen-containing;WFD;Lead nitrate;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C07115;Nitrogen-containing;IARC2A;Nitrogen mustard;reductase
+Pseudomonas aeruginosa - pae;K00383;GSR;glutathione reductase (NADPH) ;C15234;Metal;WFD;Lead nitrate;reductase
+Pseudomonas aeruginosa - pae;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Pseudomonas aeruginosa - pae;K00528;fpr;ferredoxin/flavodoxin---NADP+ reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Pseudomonas aeruginosa - pae;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Pseudomonas aeruginosa - pae;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Pseudomonas aeruginosa - pae;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K00432;gpx;glutathione peroxidase ;C01576;Polyaromatic;IARC1;Etoposide;peroxidase
+Pseudomonas aeruginosa - pae;K00569;TPMT;thiopurine S-methyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;methyltransferase
+Pseudomonas aeruginosa - pae;K00569;TPMT;thiopurine S-methyltransferase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;methyltransferase
+Pseudomonas aeruginosa - pae;K00569;TPMT;thiopurine S-methyltransferase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;methyltransferase
+Pseudomonas aeruginosa - pae;K00569;TPMT;thiopurine S-methyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;methyltransferase
+Pseudomonas aeruginosa - pae;K00569;TPMT;thiopurine S-methyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;methyltransferase
+Pseudomonas aeruginosa - pae;K00569;TPMT;thiopurine S-methyltransferase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;methyltransferase
+Pseudomonas aeruginosa - pae;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Pseudomonas aeruginosa - pae;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00845;glk;glucokinase ;C15234;Metal;EPC;Lead nitrate;glucokinase
+Pseudomonas aeruginosa - pae;K00845;glk;glucokinase ;C15234;Inorganic;WFD;Lead nitrate;glucokinase
+Pseudomonas aeruginosa - pae;K00845;glk;glucokinase ;C15234;Nitrogen-containing;EPC;Lead nitrate;glucokinase
+Pseudomonas aeruginosa - pae;K00845;glk;glucokinase ;C15234;Metal;WFD;Lead nitrate;glucokinase
+Pseudomonas aeruginosa - pae;K00845;glk;glucokinase ;C15234;Nitrogen-containing;WFD;Lead nitrate;glucokinase
+Pseudomonas aeruginosa - pae;K00845;glk;glucokinase ;C15234;Inorganic;EPC;Lead nitrate;glucokinase
+Pseudomonas aeruginosa - pae;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00266;gltD;glutamate synthase (NADPH) small chain ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Pseudomonas aeruginosa - pae;K00266;gltD;glutamate synthase (NADPH) small chain ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Pseudomonas aeruginosa - pae;K00266;gltD;glutamate synthase (NADPH) small chain ;C11906;Inorganic;ATSDR;Sodium arsenite;synthase
+Pseudomonas aeruginosa - pae;K00266;gltD;glutamate synthase (NADPH) small chain ;C11906;Metal;ATSDR;Sodium arsenite;synthase
+Pseudomonas aeruginosa - pae;K00265;gltB;glutamate synthase (NADPH) large chain ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Pseudomonas aeruginosa - pae;K00265;gltB;glutamate synthase (NADPH) large chain ;C11906;Metal;ATSDR;Sodium arsenite;synthase
+Pseudomonas aeruginosa - pae;K00265;gltB;glutamate synthase (NADPH) large chain ;C11906;Inorganic;ATSDR;Sodium arsenite;synthase
+Pseudomonas aeruginosa - pae;K00265;gltB;glutamate synthase (NADPH) large chain ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Pseudomonas aeruginosa - pae;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00285;dadA;D-amino-acid dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;ATSDR;Fluoranthene;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;EPA;Acenaphthene;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19304;Sulfur-containing;IARC2B;Thiouracil;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;WFD;Fluoranthene;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPA;Fluoranthene;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19304;Aliphatic;IARC2B;Thiouracil;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;ATSDR;Acenaphthene;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPC;Fluoranthene;chloroperoxidase
+Pseudomonas aeruginosa - pae;K00340;nuoK;NADH-quinone oxidoreductase subunit K ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00341;nuoL;NADH-quinone oxidoreductase subunit L ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00342;nuoM;NADH-quinone oxidoreductase subunit M ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00338;nuoI;NADH-quinone oxidoreductase subunit I ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;PSL;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;EPA;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;ATSDR;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00405;ccoO;cytochrome c oxidase cbb3-type subunit II;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00405;ccoO;cytochrome c oxidase cbb3-type subunit II;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00405;ccoO;cytochrome c oxidase cbb3-type subunit II;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00405;ccoO;cytochrome c oxidase cbb3-type subunit II;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00406;ccoP;cytochrome c oxidase cbb3-type subunit III;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00406;ccoP;cytochrome c oxidase cbb3-type subunit III;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00406;ccoP;cytochrome c oxidase cbb3-type subunit III;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00406;ccoP;cytochrome c oxidase cbb3-type subunit III;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00330;nuoA;NADH-quinone oxidoreductase subunit A ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00330;nuoA;NADH-quinone oxidoreductase subunit A ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00339;nuoJ;NADH-quinone oxidoreductase subunit J ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00334;nuoE;NADH-quinone oxidoreductase subunit E ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00336;nuoG;NADH-quinone oxidoreductase subunit G ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00337;nuoH;NADH-quinone oxidoreductase subunit H ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00343;nuoN;NADH-quinone oxidoreductase subunit N ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;PSL;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;EPA;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;ATSDR;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;PSL;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;EPA;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;ATSDR;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;PSL;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;EPA;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C00070;Metal;ATSDR;Copper;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;IARC1;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;ATSDR;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Aromatic;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;EPA;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00404;ccoN;cytochrome c oxidase cbb3-type subunit I ;C16444;Nitrogen-containing;PSL;Benzidine;oxidase
+Pseudomonas aeruginosa - pae;K00335;nuoF;NADH-quinone oxidoreductase subunit F ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00331;nuoB;NADH-quinone oxidoreductase subunit B ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00355;NQO1;NAD(P)H dehydrogenase (quinone) ;C10312;Aromatic;IARC2B;Danthron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00355;NQO1;NAD(P)H dehydrogenase (quinone) ;C10312;Aromatic;IARC2B;Danthron;dehydrogenase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00355;NQO1;NAD(P)H dehydrogenase (quinone) ;C10312;Aromatic;IARC2B;Danthron;dehydrogenase
+Pseudomonas aeruginosa - pae;K15864;nirS;nitrite reductase (NO-forming) / hydroxylamine reductase ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K15864;nirS;nitrite reductase (NO-forming) / hydroxylamine reductase ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K15864;nirS;nitrite reductase (NO-forming) / hydroxylamine reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Pseudomonas aeruginosa - pae;K15864;nirS;nitrite reductase (NO-forming) / hydroxylamine reductase ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00374;narI;nitrate reductase gamma subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00374;narI;nitrate reductase gamma subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00374;narI;nitrate reductase gamma subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00374;narI;nitrate reductase gamma subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00370;narG;nitrate reductase / nitrite oxidoreductase, alpha subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Pseudomonas aeruginosa - pae;K00371;narH;nitrate reductase / nitrite oxidoreductase, beta subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;EPC;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;EPC;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10805;tesB;acyl-CoA thioesterase II ;C14322;Organophosphorus;WFD;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;ATSDR;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10805;tesB;acyl-CoA thioesterase II ;C14322;Chlorinated;WFD;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10816;hcnC;hydrogen cyanide synthase HcnC ;C00177;Inorganic;ATSDR;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10816;hcnC;hydrogen cyanide synthase HcnC ;C00177;Nitrogen-containing;EPA;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10816;hcnC;hydrogen cyanide synthase HcnC ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;synthase
+Pseudomonas aeruginosa - pae;K10816;hcnC;hydrogen cyanide synthase HcnC ;C00177;Inorganic;WFD;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10816;hcnC;hydrogen cyanide synthase HcnC ;C00177;Inorganic;EPA;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10816;hcnC;hydrogen cyanide synthase HcnC ;C00177;Nitrogen-containing;ATSDR;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10816;hcnC;hydrogen cyanide synthase HcnC ;C00177;Nitrogen-containing;WFD;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10815;hcnB;hydrogen cyanide synthase HcnB ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;synthase
+Pseudomonas aeruginosa - pae;K10815;hcnB;hydrogen cyanide synthase HcnB ;C00177;Inorganic;WFD;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10815;hcnB;hydrogen cyanide synthase HcnB ;C00177;Inorganic;EPA;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10815;hcnB;hydrogen cyanide synthase HcnB ;C00177;Nitrogen-containing;ATSDR;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10815;hcnB;hydrogen cyanide synthase HcnB ;C00177;Nitrogen-containing;EPA;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10815;hcnB;hydrogen cyanide synthase HcnB ;C00177;Nitrogen-containing;WFD;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10815;hcnB;hydrogen cyanide synthase HcnB ;C00177;Inorganic;ATSDR;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10814;hcnA;hydrogen cyanide synthase HcnA ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;synthase
+Pseudomonas aeruginosa - pae;K10814;hcnA;hydrogen cyanide synthase HcnA ;C00177;Inorganic;WFD;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10814;hcnA;hydrogen cyanide synthase HcnA ;C00177;Inorganic;EPA;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10814;hcnA;hydrogen cyanide synthase HcnA ;C00177;Nitrogen-containing;WFD;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10814;hcnA;hydrogen cyanide synthase HcnA ;C00177;Nitrogen-containing;ATSDR;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10814;hcnA;hydrogen cyanide synthase HcnA ;C00177;Nitrogen-containing;EPA;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K10814;hcnA;hydrogen cyanide synthase HcnA ;C00177;Inorganic;ATSDR;Cyanide ion;synthase
+Pseudomonas aeruginosa - pae;K00496;alkB1_2;alkane 1-monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K00496;alkB1_2;alkane 1-monooxygenase ;C11344;Aliphatic;PSL;Methyl tert-butyl ether;monooxygenase
+Pseudomonas aeruginosa - pae;K00496;alkB1_2;alkane 1-monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;WFD;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;WFD;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;EPC;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C15584;Aromatic;PSL;Phenol;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;CONAMA;Phenol;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;EPA;Phenol;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;ATSDR;Phenol;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C14322;Organophosphorus;EPC;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C00146;Aromatic;PSL;Phenol;thioesterase
+Pseudomonas aeruginosa - pae;K10804;tesA;acyl-CoA thioesterase I ;C14322;Chlorinated;ATSDR;Chlorpyrifos;thioesterase
+Pseudomonas aeruginosa - pae;K13541;cbiGH-cobJ;cobalt-precorrin 5A hydrolase / cobalt-factor III methyltransferase / precorrin-3B C17-methyltransferase ;C00084;Aliphatic;IARC1;Acetaldehyde;hydrolase
+Pseudomonas aeruginosa - pae;K13541;cbiGH-cobJ;cobalt-precorrin 5A hydrolase / cobalt-factor III methyltransferase / precorrin-3B C17-methyltransferase ;C00084;Aliphatic;IARC2B;Acetaldehyde;hydrolase
+Pseudomonas aeruginosa - pae;K13541;cbiGH-cobJ;cobalt-precorrin 5A hydrolase / cobalt-factor III methyltransferase / precorrin-3B C17-methyltransferase ;C00084;Aliphatic;PSL;Acetaldehyde;hydrolase
+Pseudomonas aeruginosa - pae;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Pseudomonas aeruginosa - pae;K00274;MAO;monoamine oxidase ;C07675;Nitrogen-containing;IARC2A;Pioglitazone;oxidase
+Pseudomonas aeruginosa - pae;K00274;MAO;monoamine oxidase ;C07675;Sulfur-containing;IARC2A;Pioglitazone;oxidase
+Pseudomonas aeruginosa - pae;K00274;MAO;monoamine oxidase ;C07675;Aromatic;IARC2A;Pioglitazone;oxidase
+Pseudomonas aeruginosa - pae;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Pseudomonas aeruginosa - pae;K00274;MAO;monoamine oxidase ;C19263;Aliphatic;IARC2B;Methyl isobutyl ketone;oxidase
+Pseudomonas aeruginosa - pae;K00274;MAO;monoamine oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Pseudomonas aeruginosa - pae;K11444;wspR;two-component system, chemotaxis family, response regulator WspR ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;#N/D
+Pseudomonas aeruginosa - pae;K11444;wspR;two-component system, chemotaxis family, response regulator WspR ;C07316;Polyaromatic;IARC2B;Sulfasalazine;#N/D
+Pseudomonas aeruginosa - pae;K11444;wspR;two-component system, chemotaxis family, response regulator WspR ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;#N/D
+Pseudomonas aeruginosa - pae;K10680;nemA;N-ethylmaleimide reductase ;C16391;Nitrogen-containing;ATSDR;Trinitrotoluene;reductase
+Pseudomonas aeruginosa - pae;K10680;nemA;N-ethylmaleimide reductase ;C16391;Aromatic;ATSDR;Trinitrotoluene;reductase
+Pseudomonas aeruginosa - pae;K00148;fdhA;glutathione-independent formaldehyde dehydrogenase ;C00067;Aliphatic;IARC1;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00148;fdhA;glutathione-independent formaldehyde dehydrogenase ;C00067;Aliphatic;PSL;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00148;fdhA;glutathione-independent formaldehyde dehydrogenase ;C00067;Aliphatic;ATSDR;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00523;ascD;CDP-4-dehydro-6-deoxyglucose reductase, E3 ;C11195;Polyaromatic;IARC2B;Mitoxantrone;reductase
+Pseudomonas aeruginosa - pae;K00523;ascD;CDP-4-dehydro-6-deoxyglucose reductase, E3 ;C11195;Nitrogen-containing;IARC2B;Mitoxantrone;reductase
+Pseudomonas aeruginosa - pae;K12251;aguB;N-carbamoylputrescine amidase ;C00014;Nitrogen-containing;PSL;Ammonia;amidase
+Pseudomonas aeruginosa - pae;K12251;aguB;N-carbamoylputrescine amidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidase
+Pseudomonas aeruginosa - pae;K11065;tpx;thioredoxin-dependent peroxiredoxin ;C19359;Nitrogen-containing;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Pseudomonas aeruginosa - pae;K11065;tpx;thioredoxin-dependent peroxiredoxin ;C19359;Chlorinated;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Pseudomonas aeruginosa - pae;K11311;antC;anthranilate 1,2-dioxygenase reductase component ;C00014;Nitrogen-containing;ATSDR;Ammonia;dioxygenase
+Pseudomonas aeruginosa - pae;K11311;antC;anthranilate 1,2-dioxygenase reductase component ;C00090;Aromatic;EPC;Catechol;dioxygenase
+Pseudomonas aeruginosa - pae;K11311;antC;anthranilate 1,2-dioxygenase reductase component ;C00090;Aromatic;WFD;Catechol;dioxygenase
+Pseudomonas aeruginosa - pae;K11311;antC;anthranilate 1,2-dioxygenase reductase component ;C00014;Nitrogen-containing;PSL;Ammonia;dioxygenase
+Pseudomonas aeruginosa - pae;K11311;antC;anthranilate 1,2-dioxygenase reductase component ;C00090;Aromatic;PSL;Catechol;dioxygenase
+Pseudomonas aeruginosa - pae;K11311;antC;anthranilate 1,2-dioxygenase reductase component ;C00090;Aromatic;IARC2B;Catechol;dioxygenase
+Pseudomonas aeruginosa - pae;K11311;antC;anthranilate 1,2-dioxygenase reductase component ;C00090;Aromatic;ATSDR;Catechol;dioxygenase
+Pseudomonas aeruginosa - pae;K00479;gbcA;glycine betaine monooxygenase A ;C00067;Aliphatic;PSL;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00479;gbcA;glycine betaine monooxygenase A ;C00067;Aliphatic;IARC1;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00479;gbcA;glycine betaine monooxygenase A ;C00067;Aliphatic;ATSDR;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00496;alkB1_2;alkane 1-monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K00496;alkB1_2;alkane 1-monooxygenase ;C11344;Aliphatic;PSL;Methyl tert-butyl ether;monooxygenase
+Pseudomonas aeruginosa - pae;K00496;alkB1_2;alkane 1-monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Pseudomonas aeruginosa - pae;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Pseudomonas aeruginosa - pae;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Pseudomonas aeruginosa - pae;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Pseudomonas aeruginosa - pae;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Pseudomonas aeruginosa - pae;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Pseudomonas aeruginosa - pae;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K15371;GDH2;glutamate dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Pseudomonas aeruginosa - pae;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Pseudomonas aeruginosa - pae;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Nitrogen-containing;IARC2A;Methylnitrosourea;deacetylase
+Pseudomonas aeruginosa - pae;K12410;cobB;NAD-dependent protein deacetylase/lipoamidase ;C14595;Aliphatic;IARC2A;Methylnitrosourea;deacetylase
+Pseudomonas aeruginosa - pae;K12238;pchD;salicylate---[aryl-carrier protein] ligase ;C00805;Aromatic;EPC;Salicylate;ligase
+Pseudomonas aeruginosa - pae;K12238;pchD;salicylate---[aryl-carrier protein] ligase ;C00805;Aromatic;PSL;Salicylate;ligase
+Pseudomonas aeruginosa - pae;K12238;pchD;salicylate---[aryl-carrier protein] ligase ;C00805;Aromatic;WFD;Salicylate;ligase
+Pseudomonas aeruginosa - pae;K12238;pchD;salicylate---[aryl-carrier protein] ligase ;C00805;Aromatic;ATSDR;Salicylate;ligase
+Pseudomonas aeruginosa - pae;K11915;stp1;serine/threonine protein phosphatase Stp1 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Pseudomonas aeruginosa - pae;K11915;stp1;serine/threonine protein phosphatase Stp1 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Pseudomonas aeruginosa - pae;K11915;stp1;serine/threonine protein phosphatase Stp1 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Pseudomonas aeruginosa - pae;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K13590;dgcB;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K13590;dgcB;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K13590;dgcB;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K10680;nemA;N-ethylmaleimide reductase ;C16391;Nitrogen-containing;ATSDR;Trinitrotoluene;reductase
+Pseudomonas aeruginosa - pae;K10680;nemA;N-ethylmaleimide reductase ;C16391;Aromatic;ATSDR;Trinitrotoluene;reductase
+Pseudomonas aeruginosa - pae;K13378;nuoCD;NADH-quinone oxidoreductase subunit C/D ;C07210;Nitrogen-containing;IARC2B;Zidovudine;oxidoreductase
+Pseudomonas aeruginosa - pae;K13378;nuoCD;NADH-quinone oxidoreductase subunit C/D ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;oxidoreductase
+Pseudomonas aeruginosa - pae;K10778;ada;AraC family transcriptional regulator, regulatory protein of adaptative response / methylated-DNA-[protein]-cysteine methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Pseudomonas aeruginosa - pae;K10778;ada;AraC family transcriptional regulator, regulatory protein of adaptative response / methylated-DNA-[protein]-cysteine methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00249;ACADM;acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Pseudomonas aeruginosa - pae;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Pseudomonas aeruginosa - pae;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K13953;adhP;alcohol dehydrogenase, propanol-preferring ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Pseudomonas aeruginosa - pae;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Pseudomonas aeruginosa - pae;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K13979;yahK;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00114;exaA;alcohol dehydrogenase (cytochrome c) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Pseudomonas aeruginosa - pae;K00114;exaA;alcohol dehydrogenase (cytochrome c) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00114;exaA;alcohol dehydrogenase (cytochrome c) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00114;exaA;alcohol dehydrogenase (cytochrome c) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Pseudomonas aeruginosa - pae;K00114;exaA;alcohol dehydrogenase (cytochrome c) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Pseudomonas aeruginosa - pae;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Pseudomonas aeruginosa - pae;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K10778;ada;AraC family transcriptional regulator, regulatory protein of adaptative response / methylated-DNA-[protein]-cysteine methyltransferase ;C18447;Aliphatic;EPA;Methyl bromide;methyltransferase
+Pseudomonas aeruginosa - pae;K10778;ada;AraC family transcriptional regulator, regulatory protein of adaptative response / methylated-DNA-[protein]-cysteine methyltransferase ;C18447;Halogenated;EPA;Methyl bromide;methyltransferase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Organometallic;EPC;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Chlorinated;EPC;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Chlorinated;WFD;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Chlorinated;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Aromatic;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Organometallic;IARC2B;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C11146;Organometallic;WFD;Methylmercury chloride;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Nitrogen-containing;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K13938;folM;dihydromonapterin reductase / dihydrofolate reductase ;C07041;Sulfur-containing;IARC2B;Hydrochlorothiazide;reductase
+Pseudomonas aeruginosa - pae;K14268;davT;5-aminovalerate/4-aminobutyrate aminotransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;aminotransferase
+Pseudomonas aeruginosa - pae;K14268;davT;5-aminovalerate/4-aminobutyrate aminotransferase ;C19304;Aliphatic;IARC2B;Thiouracil;aminotransferase
+Pseudomonas aeruginosa - pae;K14268;davT;5-aminovalerate/4-aminobutyrate aminotransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;aminotransferase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;WFD;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;ATSDR;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C02116;Aliphatic;IARC2B;2-Nitropropane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00088;Nitrogen-containing;ATSDR;Nitrite;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC1;Acetaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00088;Inorganic;ATSDR;Nitrite;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;WFD;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;PSL;Acetaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K18540;ramA;(R)-amidase ;C00014;Nitrogen-containing;PSL;Ammonia;amidase
+Pseudomonas aeruginosa - pae;K18540;ramA;(R)-amidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidase
+Pseudomonas aeruginosa - pae;K00344;qor;NADPH:quinone reductase ;C10312;Aromatic;IARC2B;Danthron;reductase
+Pseudomonas aeruginosa - pae;K00407;ccoQ;cytochrome c oxidase cbb3-type subunit IV;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00407;ccoQ;cytochrome c oxidase cbb3-type subunit IV;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K14977;ylbA;(S)-ureidoglycine aminohydrolase ;C00014;Nitrogen-containing;PSL;Ammonia;aminohydrolase
+Pseudomonas aeruginosa - pae;K14977;ylbA;(S)-ureidoglycine aminohydrolase ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminohydrolase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;WFD;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;ATSDR;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Chlorinated;ATSDR;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C19275;Inorganic;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C02116;Aliphatic;IARC2B;2-Nitropropane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C02116;Nitrogen-containing;IARC2B;2-Nitropropane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00088;Nitrogen-containing;ATSDR;Nitrite;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC1;Acetaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00088;Inorganic;ATSDR;Nitrite;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C19275;Nitrogen-containing;IARC2B;Nitromethane;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C13377;Metal;WFD;Mercuric chloride;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00459;ncd2;nitronate monooxygenase ;C00084;Aliphatic;PSL;Acetaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Aromatic;IARC2A;Chloramphenicol;acetyltransferase
+Pseudomonas aeruginosa - pae;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Chlorinated;IARC2A;Chloramphenicol;acetyltransferase
+Pseudomonas aeruginosa - pae;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Nitrogen-containing;IARC2A;Chloramphenicol;acetyltransferase
+Pseudomonas aeruginosa - pae;K12960;mtaD;5-methylthioadenosine/S-adenosylhomocysteine deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K12960;mtaD;5-methylthioadenosine/S-adenosylhomocysteine deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K00675;nhoA;N-hydroxyarylamine O-acetyltransferase ;C19244;Aliphatic;IARC2B;Glu-P-1;acetyltransferase
+Pseudomonas aeruginosa - pae;K00675;nhoA;N-hydroxyarylamine O-acetyltransferase ;C19244;Nitrogen-containing;IARC2B;Glu-P-1;acetyltransferase
+Pseudomonas aeruginosa - pae;K18456;E3.5.4.32;8-oxoguanine deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K18456;E3.5.4.32;8-oxoguanine deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;ATSDR;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;IARC2B;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C00067;Aliphatic;ATSDR;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;ATSDR;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;EPA;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Aliphatic;PSL;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C00067;Aliphatic;IARC1;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;PSL;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C00067;Aliphatic;PSL;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;IARC2B;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17228;sfnG;dimethylsulfone monooxygenase ;C19534;Chlorinated;EPA;1,1,2,2-Tetrachloroethane;monooxygenase
+Pseudomonas aeruginosa - pae;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Pseudomonas aeruginosa - pae;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Pseudomonas aeruginosa - pae;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Pseudomonas aeruginosa - pae;K19746;dauA;D-arginine dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K19746;dauA;D-arginine dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Pseudomonas aeruginosa - pae;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Pseudomonas aeruginosa - pae;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Pseudomonas aeruginosa - pae;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Pseudomonas aeruginosa - pae;K00004;BDH;(R,R)-butanediol dehydrogenase / meso-butanediol dehydrogenase / diacetyl reductase ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Pseudomonas aeruginosa - pae;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K00138;aldB;aldehyde dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K22589;thadh;threo-3-hydroxy-L-aspartate ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Pseudomonas aeruginosa - pae;K22589;thadh;threo-3-hydroxy-L-aspartate ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K11915;stp1;serine/threonine protein phosphatase Stp1 ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphatase
+Pseudomonas aeruginosa - pae;K11915;stp1;serine/threonine protein phosphatase Stp1 ;C10984;Polyaromatic;EPC;Cypermethrin;phosphatase
+Pseudomonas aeruginosa - pae;K11915;stp1;serine/threonine protein phosphatase Stp1 ;C10984;Chlorinated;EPC;Cypermethrin;phosphatase
+Pseudomonas aeruginosa - pae;K21021;tpbB;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21021;tpbB;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21021;tpbB;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21019;sadC;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21019;sadC;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21019;sadC;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21062;lhpC;1-pyrroline-4-hydroxy-2-carboxylate deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K21062;lhpC;1-pyrroline-4-hydroxy-2-carboxylate deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K21053;ade;adenine deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K21020;siaD;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21020;siaD;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21020;siaD;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21022;roeA;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21022;roeA;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21022;roeA;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C05371;Nitrogen-containing;IARC2B;Microcystin LR;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C05371;Aromatic;IARC2B;Microcystin LR;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K21253;fosA;glutathione S-transferase fosA ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K22952;pvcA;L-tyrosine isonitrile synthase ;C00067;Aliphatic;ATSDR;Formaldehyde;synthase
+Pseudomonas aeruginosa - pae;K22952;pvcA;L-tyrosine isonitrile synthase ;C00067;Aliphatic;PSL;Formaldehyde;synthase
+Pseudomonas aeruginosa - pae;K22952;pvcA;L-tyrosine isonitrile synthase ;C00067;Aliphatic;IARC1;Formaldehyde;synthase
+Pseudomonas aeruginosa - pae;K21833;dgcA;N,N-dimethylglycine/sarcosine dehydrogenase ;C00067;Aliphatic;PSL;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K21833;dgcA;N,N-dimethylglycine/sarcosine dehydrogenase ;C00067;Aliphatic;IARC1;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K21833;dgcA;N,N-dimethylglycine/sarcosine dehydrogenase ;C00067;Aliphatic;ATSDR;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K21834;dgcB;N,N-dimethylglycine/sarcosine dehydrogenase ferredoxin subunit;C00067;Aliphatic;IARC1;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K21834;dgcB;N,N-dimethylglycine/sarcosine dehydrogenase ferredoxin subunit;C00067;Aliphatic;ATSDR;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K21834;dgcB;N,N-dimethylglycine/sarcosine dehydrogenase ferredoxin subunit;C00067;Aliphatic;PSL;Formaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K21832;gbcB;glycine betaine monooxygenase B ;C00067;Aliphatic;PSL;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K21832;gbcB;glycine betaine monooxygenase B ;C00067;Aliphatic;ATSDR;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K21832;gbcB;glycine betaine monooxygenase B ;C00067;Aliphatic;IARC1;Formaldehyde;monooxygenase
+Pseudomonas aeruginosa - pae;K22345;E4.3.1.9;glucosaminate ammonia-lyase ;C00014;Nitrogen-containing;ATSDR;Ammonia;lyase
+Pseudomonas aeruginosa - pae;K22345;E4.3.1.9;glucosaminate ammonia-lyase ;C00014;Nitrogen-containing;PSL;Ammonia;lyase
+Pseudomonas aeruginosa - pae;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;amidase
+Pseudomonas aeruginosa - pae;K13566;NIT2;omega-amidase ;C00014;Nitrogen-containing;PSL;Ammonia;amidase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C00014;Nitrogen-containing;ATSDR;Ammonia;glutamyltransferase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;glutamyltransferase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C14322;Chlorinated;WFD;Chlorpyrifos;glutamyltransferase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;glutamyltransferase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C00014;Nitrogen-containing;PSL;Ammonia;glutamyltransferase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;glutamyltransferase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;glutamyltransferase
+Pseudomonas aeruginosa - pae;K22452;tgpA;protein-glutamine gamma-glutamyltransferase ;C14322;Chlorinated;EPC;Chlorpyrifos;glutamyltransferase
+Pseudomonas aeruginosa - pae;K25961;etfB;N,N-dimethylglycine/sarcosine catabolism electron transfer flavoprotein subunit beta;C00067;Aliphatic;IARC1;Formaldehyde;#N/D
+Pseudomonas aeruginosa - pae;K25961;etfB;N,N-dimethylglycine/sarcosine catabolism electron transfer flavoprotein subunit beta;C00067;Aliphatic;ATSDR;Formaldehyde;#N/D
+Pseudomonas aeruginosa - pae;K25961;etfB;N,N-dimethylglycine/sarcosine catabolism electron transfer flavoprotein subunit beta;C00067;Aliphatic;PSL;Formaldehyde;#N/D
+Pseudomonas aeruginosa - pae;K25960;etfA;N,N-dimethylglycine/sarcosine catabolism electron transfer flavoprotein subunit alpha;C00067;Aliphatic;IARC1;Formaldehyde;#N/D
+Pseudomonas aeruginosa - pae;K25960;etfA;N,N-dimethylglycine/sarcosine catabolism electron transfer flavoprotein subunit alpha;C00067;Aliphatic;ATSDR;Formaldehyde;#N/D
+Pseudomonas aeruginosa - pae;K25960;etfA;N,N-dimethylglycine/sarcosine catabolism electron transfer flavoprotein subunit alpha;C00067;Aliphatic;PSL;Formaldehyde;#N/D
+Pseudomonas aeruginosa - pae;K21023;mucR;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21023;mucR;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21023;mucR;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00248;ACADS;butyryl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K24158;prx;thioredoxin-dependent peroxiredoxin ;C19359;Chlorinated;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Pseudomonas aeruginosa - pae;K24158;prx;thioredoxin-dependent peroxiredoxin ;C19359;Nitrogen-containing;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Pseudomonas aeruginosa - pae;K00355;NQO1;NAD(P)H dehydrogenase (quinone) ;C10312;Aromatic;IARC2B;Danthron;dehydrogenase
+Pseudomonas aeruginosa - pae;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Pseudomonas aeruginosa - pae;K22474;adhB;alcohol dehydrogenase (quinone), cytochrome c subunit ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Pseudomonas aeruginosa - pae;K22474;adhB;alcohol dehydrogenase (quinone), cytochrome c subunit ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K22474;adhB;alcohol dehydrogenase (quinone), cytochrome c subunit ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K22474;adhB;alcohol dehydrogenase (quinone), cytochrome c subunit ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Pseudomonas aeruginosa - pae;K21084;yegE;diguanylate cyclase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21084;yegE;diguanylate cyclase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K21084;yegE;diguanylate cyclase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;cyclase
+Pseudomonas aeruginosa - pae;K00407;ccoQ;cytochrome c oxidase cbb3-type subunit IV;C19231;Polyaromatic;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00407;ccoQ;cytochrome c oxidase cbb3-type subunit IV;C19231;Nitrogen-containing;IARC2B;3,3'-Dimethoxybenzidine;oxidase
+Pseudomonas aeruginosa - pae;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Aromatic;IARC2A;Chloramphenicol;acetyltransferase
+Pseudomonas aeruginosa - pae;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Chlorinated;IARC2A;Chloramphenicol;acetyltransferase
+Pseudomonas aeruginosa - pae;K00638;catB;chloramphenicol O-acetyltransferase type B ;C00918;Nitrogen-containing;IARC2A;Chloramphenicol;acetyltransferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Pseudomonas aeruginosa - pae;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Pseudomonas aeruginosa - pae;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;PSL;3,4-Dihydroxybenzoate;dehydratase
+Pseudomonas aeruginosa - pae;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;ATSDR;3,4-Dihydroxybenzoate;dehydratase
+Pseudomonas aeruginosa - pae;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;WFD;3,4-Dihydroxybenzoate;dehydratase
+Pseudomonas aeruginosa - pae;K26400;quiC1;3-dehydroshikimate dehydratase ;C00230;Aromatic;EPC;3,4-Dihydroxybenzoate;dehydratase
+Pseudomonas aeruginosa - pae;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Pseudomonas aeruginosa - pae;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Pseudomonas aeruginosa - pae;K26139;nasD;nitrite reductase [NAD(P)H] large subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K26138;nasE;nitrite reductase [NAD(P)H] small subunit ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K26138;nasE;nitrite reductase [NAD(P)H] small subunit ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Pseudomonas aeruginosa - pae;K26138;nasE;nitrite reductase [NAD(P)H] small subunit ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Pseudomonas aeruginosa - pae;K26138;nasE;nitrite reductase [NAD(P)H] small subunit ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;EPC;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Chlorinated;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;WFD;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;IARC2B;Methylmercury chloride;dehydrogenase
+Pseudomonas aeruginosa - pae;K00255;ACADL;long-chain-acyl-CoA dehydrogenase ;C11146;Organometallic;EPC;Methylmercury chloride;dehydrogenase
+Synechocystis sp;K00761;upp;uracil phosphoribosyltransferase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Synechocystis sp;K00761;upp;uracil phosphoribosyltransferase ;C19304;Aliphatic;IARC2B;Thiouracil;phosphoribosyltransferase
+Synechocystis sp;K00761;upp;uracil phosphoribosyltransferase ;C19304;Sulfur-containing;IARC2B;Thiouracil;phosphoribosyltransferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Synechocystis sp;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Synechocystis sp;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Synechocystis sp;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Synechocystis sp;K00275;pdxH;pyridoxamine 5'-phosphate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;ATSDR;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;EPC;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;WFD;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;WFD;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;WFD;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;ATSDR;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;ATSDR;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;EPC;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;EPC;Diuron;synthase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00259;ald;alanine dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Synechocystis sp;K00259;ald;alanine dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Synechocystis sp;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;PSL;Formaldehyde;hydroxymethyltransferase
+Synechocystis sp;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;ATSDR;Formaldehyde;hydroxymethyltransferase
+Synechocystis sp;K00606;panB;3-methyl-2-oxobutanoate hydroxymethyltransferase ;C00067;Aliphatic;IARC1;Formaldehyde;hydroxymethyltransferase
+Synechocystis sp;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;IARC2B;Cacodylate;dehydrogenase
+Synechocystis sp;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;IARC2B;Cacodylate;dehydrogenase
+Synechocystis sp;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Inorganic;ATSDR;Cacodylate;dehydrogenase
+Synechocystis sp;K00133;asd;aspartate-semialdehyde dehydrogenase ;C07308;Metal;ATSDR;Cacodylate;dehydrogenase
+Synechocystis sp;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Synechocystis sp;K00262;E1.4.1.4;glutamate dehydrogenase (NADP+) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Synechocystis sp;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Synechocystis sp;K00134;GAPDH;glyceraldehyde 3-phosphate dehydrogenase (phosphorylating) ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;dehydrogenase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;reductase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C00014;Nitrogen-containing;PSL;Ammonia;reductase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Organometallic;WFD;Phenylmercury acetate;reductase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Aromatic;WFD;Phenylmercury acetate;reductase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Organometallic;EPC;Phenylmercury acetate;reductase
+Synechocystis sp;K00366;nirA;ferredoxin-nitrite reductase ;C11151;Aromatic;EPC;Phenylmercury acetate;reductase
+Synechocystis sp;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Nitrogen-containing;IARC2A;Captafol;synthase
+Synechocystis sp;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Sulfur-containing;IARC2A;Captafol;synthase
+Synechocystis sp;K00652;bioF;8-amino-7-oxononanoate synthase ;C18754;Chlorinated;IARC2A;Captafol;synthase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Nitrogen-containing;IARC2B;Phenobarbital;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;EPA;Zinc cation;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00038;Metal;ATSDR;Zinc cation;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C19249;Aliphatic;IARC2B;2,4-Hexadienal;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Nitrogen-containing;IARC2B;Phenytoin;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07434;Aromatic;IARC2B;Phenobarbital;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00002;AKR1A1;alcohol dehydrogenase (NADP+) ;C07443;Polyaromatic;IARC2B;Phenytoin;dehydrogenase
+Synechocystis sp;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Synechocystis sp;K00382;DLD;dihydrolipoyl dehydrogenase ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Synechocystis sp;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Polyaromatic;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Synechocystis sp;K00681;ggt;gamma-glutamyltranspeptidase / glutathione hydrolase ;C02227;Nitrogen-containing;IARC1;2-Naphthylamine;glutamyltranspeptidase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;aminomethyltransferase
+Synechocystis sp;K00605;gcvT;glycine cleavage system T protein (aminomethyltransferase) ;C00014;Nitrogen-containing;PSL;Ammonia;aminomethyltransferase
+Synechocystis sp;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Inorganic;IARC2B;Tetranitromethane;dehydrogenase
+Synechocystis sp;K00033;PGD;6-phosphogluconate dehydrogenase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;dehydrogenase
+Synechocystis sp;K00600;glyA;glycine hydroxymethyltransferase ;C19246;Aliphatic;IARC2B;Glycidaldehyde;hydroxymethyltransferase
+Synechocystis sp;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;dioxygenase
+Synechocystis sp;K00457;HPD;4-hydroxyphenylpyruvate dioxygenase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;dioxygenase
+Synechocystis sp;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Metal;ATSDR;Sodium arsenite;dehydrogenase
+Synechocystis sp;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C13884;Metal;ATSDR;Strontium cation;dehydrogenase
+Synechocystis sp;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C11906;Inorganic;ATSDR;Sodium arsenite;dehydrogenase
+Synechocystis sp;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00128;ALDH;aldehyde dehydrogenase (NAD+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;ATSDR;Fluoranthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;EPA;Acenaphthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19304;Sulfur-containing;IARC2B;Thiouracil;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;WFD;Fluoranthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPA;Fluoranthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19304;Aliphatic;IARC2B;Thiouracil;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;ATSDR;Acenaphthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPC;Fluoranthene;chloroperoxidase
+Synechocystis sp;K00943;tmk;dTMP kinase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;kinase
+Synechocystis sp;K00927;PGK;phosphoglycerate kinase ;C07316;Sulfur-containing;IARC2B;Sulfasalazine;kinase
+Synechocystis sp;K00927;PGK;phosphoglycerate kinase ;C07316;Polyaromatic;IARC2B;Sulfasalazine;kinase
+Synechocystis sp;K00927;PGK;phosphoglycerate kinase ;C07316;Nitrogen-containing;IARC2B;Sulfasalazine;kinase
+Synechocystis sp;K00927;PGK;phosphoglycerate kinase ;C07207;Nitrogen-containing;IARC2B;Zalcitabine;kinase
+Synechocystis sp;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;synthetase
+Synechocystis sp;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPA;Carbon tetrachloride;synthetase
+Synechocystis sp;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;synthetase
+Synechocystis sp;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;EPC;Carbon tetrachloride;synthetase
+Synechocystis sp;K00789;metK;S-adenosylmethionine synthetase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;synthetase
+Synechocystis sp;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;ATSDR;Ammonia;kinase
+Synechocystis sp;K00926;arcC;carbamate kinase ;C00014;Nitrogen-containing;PSL;Ammonia;kinase
+Synechocystis sp;K00845;glk;glucokinase ;C15234;Metal;EPC;Lead nitrate;glucokinase
+Synechocystis sp;K00845;glk;glucokinase ;C15234;Inorganic;WFD;Lead nitrate;glucokinase
+Synechocystis sp;K00845;glk;glucokinase ;C15234;Nitrogen-containing;EPC;Lead nitrate;glucokinase
+Synechocystis sp;K00845;glk;glucokinase ;C15234;Metal;WFD;Lead nitrate;glucokinase
+Synechocystis sp;K00845;glk;glucokinase ;C15234;Nitrogen-containing;WFD;Lead nitrate;glucokinase
+Synechocystis sp;K00845;glk;glucokinase ;C15234;Inorganic;EPC;Lead nitrate;glucokinase
+Synechocystis sp;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;oxidase
+Synechocystis sp;K00278;nadB;L-aspartate oxidase ;C00014;Nitrogen-containing;PSL;Ammonia;oxidase
+Synechocystis sp;K00278;nadB;L-aspartate oxidase ;C19300;Inorganic;IARC2B;Tetranitromethane;oxidase
+Synechocystis sp;K00278;nadB;L-aspartate oxidase ;C19300;Nitrogen-containing;IARC2B;Tetranitromethane;oxidase
+Synechocystis sp;K00688;PYG;glycogen phosphorylase ;C10984;Chlorinated;EPC;Cypermethrin;phosphorylase
+Synechocystis sp;K00688;PYG;glycogen phosphorylase ;C10984;Nitrogen-containing;EPC;Cypermethrin;phosphorylase
+Synechocystis sp;K00688;PYG;glycogen phosphorylase ;C10984;Polyaromatic;EPC;Cypermethrin;phosphorylase
+Synechocystis sp;K00864;glpK;glycerol kinase ;C18676;Chlorinated;IARC2B;alpha-Chlorohydrin;kinase
+Synechocystis sp;K00864;glpK;glycerol kinase ;C18676;Aliphatic;IARC2B;alpha-Chlorohydrin;kinase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;WFD;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;ATSDR;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Nitrogen-containing;EPC;Cypermethrin;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;ATSDR;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Polyaromatic;EPC;Cypermethrin;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;EPC;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;WFD;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C10984;Chlorinated;EPC;Cypermethrin;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;EPC;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Aromatic;EPC;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Nitrogen-containing;WFD;Diuron;dehydrogenase
+Synechocystis sp;K00036;G6PD;glucose-6-phosphate 1-dehydrogenase ;C18428;Chlorinated;ATSDR;Diuron;dehydrogenase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPC;Carbon tetrachloride;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;EPA;Carbon tetrachloride;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Aliphatic;IARC2B;Thioacetamide;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C10312;Aromatic;IARC2B;Danthron;reductase
+Synechocystis sp;K00384;trxB;thioredoxin reductase (NADPH) ;C19302;Sulfur-containing;IARC2B;Thioacetamide;reductase
+Synechocystis sp;K00367;narB;ferredoxin-nitrate reductase ;C00244;Nitrogen-containing;ATSDR;Nitrate;reductase
+Synechocystis sp;K00367;narB;ferredoxin-nitrate reductase ;C00088;Inorganic;ATSDR;Nitrite;reductase
+Synechocystis sp;K00367;narB;ferredoxin-nitrate reductase ;C00244;Inorganic;ATSDR;Nitrate;reductase
+Synechocystis sp;K00367;narB;ferredoxin-nitrate reductase ;C00088;Nitrogen-containing;ATSDR;Nitrite;reductase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Chlorinated;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Polyaromatic;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Nitrogen-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;WFD;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Aliphatic;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;ATSDR;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Sulfur-containing;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;ATSDR;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;ATSDR;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Chlorinated;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPC;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;CONAMA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C19586;Aromatic;IARC1;Aflatoxin B1-exo-8,9-epoxide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C01326;Nitrogen-containing;ATSDR;Hydrogen cyanide;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Chlorinated;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;WFD;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10984;Nitrogen-containing;EPC;Cypermethrin;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Nitrogen-containing;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Chlorinated;EPC;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;EPA;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C10928;Aromatic;EPC;Alachlor;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;ATSDR;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPA;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14322;Organophosphorus;WFD;Chlorpyrifos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Organophosphorus;EPC;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11090;Inorganic;ATSDR;Endosulfan;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14430;Chlorinated;IARC2B;Dichlorvos;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11088;Organometallic;IARC2A;1,2-Dibromoethane;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Chlorinated;EPC;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;PSL;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C06790;Aliphatic;IARC1;Trichloroethene;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C11278;Aromatic;IARC1;Aflatoxin B1exo-8,9-epoxide-GSH;transferase
+Synechocystis sp;K00799;GST;glutathione S-transferase ;C14449;Chlorinated;IARC2A;Epichlorohydrin;transferase
+Synechocystis sp;K00266;gltD;glutamate synthase (NADPH) small chain ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Synechocystis sp;K00266;gltD;glutamate synthase (NADPH) small chain ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Synechocystis sp;K00266;gltD;glutamate synthase (NADPH) small chain ;C11906;Inorganic;ATSDR;Sodium arsenite;synthase
+Synechocystis sp;K00266;gltD;glutamate synthase (NADPH) small chain ;C11906;Metal;ATSDR;Sodium arsenite;synthase
+Synechocystis sp;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Synechocystis sp;K11752;ribD;diaminohydroxyphosphoribosylaminopyrimidine deaminase / 5-amino-6-(5-phosphoribosylamino)uracil reductase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Synechocystis sp;K11780;cofG;7,8-didemethyl-8-hydroxy-5-deazariboflavin synthase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Synechocystis sp;K11780;cofG;7,8-didemethyl-8-hydroxy-5-deazariboflavin synthase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Synechocystis sp;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Synechocystis sp;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Synechocystis sp;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Synechocystis sp;K12957;ahr;alcohol/geraniol dehydrogenase (NADP+) ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Synechocystis sp;K13541;cbiGH-cobJ;cobalt-precorrin 5A hydrolase / cobalt-factor III methyltransferase / precorrin-3B C17-methyltransferase ;C00084;Aliphatic;IARC1;Acetaldehyde;hydrolase
+Synechocystis sp;K13541;cbiGH-cobJ;cobalt-precorrin 5A hydrolase / cobalt-factor III methyltransferase / precorrin-3B C17-methyltransferase ;C00084;Aliphatic;IARC2B;Acetaldehyde;hydrolase
+Synechocystis sp;K13541;cbiGH-cobJ;cobalt-precorrin 5A hydrolase / cobalt-factor III methyltransferase / precorrin-3B C17-methyltransferase ;C00084;Aliphatic;PSL;Acetaldehyde;hydrolase
+Synechocystis sp;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;ATSDR;Ammonia;dehydrogenase
+Synechocystis sp;K00281;GLDC;glycine cleavage system P protein (glycine dehydrogenase) ;C00014;Nitrogen-containing;PSL;Ammonia;dehydrogenase
+Synechocystis sp;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;WFD;Lead nitrate;acetyltransferase
+Synechocystis sp;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;WFD;Lead nitrate;acetyltransferase
+Synechocystis sp;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Inorganic;EPC;Lead nitrate;acetyltransferase
+Synechocystis sp;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Nitrogen-containing;EPC;Lead nitrate;acetyltransferase
+Synechocystis sp;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;EPC;Lead nitrate;acetyltransferase
+Synechocystis sp;K00620;argJ;glutamate N-acetyltransferase / amino-acid N-acetyltransferase ;C15234;Metal;WFD;Lead nitrate;acetyltransferase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;ATSDR;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;EPC;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;WFD;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;WFD;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;WFD;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Aromatic;ATSDR;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;ATSDR;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Nitrogen-containing;EPC;Diuron;synthase
+Synechocystis sp;K00284;GLU;glutamate synthase (ferredoxin) ;C18428;Chlorinated;EPC;Diuron;synthase
+Synechocystis sp;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;PSL;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC2B;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00469;Aliphatic;IARC1;Ethanol;dehydrogenase
+Synechocystis sp;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Chlorinated;IARC2A;Chloral hydrate;dehydrogenase
+Synechocystis sp;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C06899;Aliphatic;IARC2A;Chloral hydrate;dehydrogenase
+Synechocystis sp;K00121;frmA;S-(hydroxymethyl)glutathione dehydrogenase / alcohol dehydrogenase ;C00084;Aliphatic;IARC1;Acetaldehyde;dehydrogenase
+Synechocystis sp;K00024;mdh;malate dehydrogenase ;C06747;Aromatic;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Synechocystis sp;K00024;mdh;malate dehydrogenase ;C08142;Inorganic;PSL;Sodium fluoride;dehydrogenase
+Synechocystis sp;K00024;mdh;malate dehydrogenase ;C06747;Sulfur-containing;PSL;Phenylmethanesulfonyl fluoride;dehydrogenase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;ATSDR;Fluoranthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19304;Nitrogen-containing;IARC2B;Thiouracil;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;EPA;Acenaphthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19304;Sulfur-containing;IARC2B;Thiouracil;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;WFD;Fluoranthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPA;Fluoranthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19304;Aliphatic;IARC2B;Thiouracil;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19312;Polyaromatic;ATSDR;Acenaphthene;chloroperoxidase
+Synechocystis sp;K00433;cpo;non-heme chloroperoxidase ;C19425;Polyaromatic;EPC;Fluoranthene;chloroperoxidase
+Synechocystis sp;K14331;K14331;fatty aldehyde decarbonylase ;C00237;Inorganic;ATSDR;CO;decarbonylase
+Synechocystis sp;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;PSL;Ammonia;deaminase
+Synechocystis sp;K11991;tadA;tRNA(adenine34) deaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;deaminase
+Synechocystis sp;K17686;copA;P-type Cu+ transporter ;C00070;Metal;ATSDR;Copper;P-type Cu+ transporter
+Synechocystis sp;K17686;copA;P-type Cu+ transporter ;C00070;Metal;EPA;Copper;P-type Cu+ transporter
+Synechocystis sp;K17686;copA;P-type Cu+ transporter ;C00070;Metal;PSL;Copper;P-type Cu+ transporter
+Synechocystis sp;K21480;HO;heme oxygenase (biliverdin-producing, ferredoxin) ;C00237;Inorganic;ATSDR;CO;oxygenase
+Synechocystis sp;K21480;HO;heme oxygenase (biliverdin-producing, ferredoxin) ;C00237;Inorganic;ATSDR;CO;oxygenase
+Synechocystis sp;K23265;purQ;phosphoribosylformylglycinamidine synthase subunit PurQ / glutaminase ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Synechocystis sp;K23265;purQ;phosphoribosylformylglycinamidine synthase subunit PurQ / glutaminase ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Synechocystis sp;K23393;murT;lipid II isoglutaminyl synthase (glutamine-hydrolysing) ;C00014;Nitrogen-containing;ATSDR;Ammonia;synthase
+Synechocystis sp;K23393;murT;lipid II isoglutaminyl synthase (glutamine-hydrolysing) ;C00014;Nitrogen-containing;PSL;Ammonia;synthase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;CONAMA;Carbon tetrachloride;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;EPC;Carbon tetrachloride;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;IARC2B;Carbon tetrachloride;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;EPA;Carbon tetrachloride;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C19302;Nitrogen-containing;IARC2B;Thioacetamide;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07210;Nitrogen-containing;IARC2B;Zidovudine;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C07561;Chlorinated;ATSDR;Carbon tetrachloride;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C19302;Aliphatic;IARC2B;Thioacetamide;nucleotidase
+Synechocystis sp;K11751;ushA;5'-nucleotidase / UDP-sugar diphosphatase ;C19302;Sulfur-containing;IARC2B;Thioacetamide;nucleotidase
+Synechocystis sp;K24157;prxII;thioredoxin-dependent peroxiredoxin ;C19359;Chlorinated;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Synechocystis sp;K24157;prxII;thioredoxin-dependent peroxiredoxin ;C19359;Nitrogen-containing;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Synechocystis sp;K24158;prx;thioredoxin-dependent peroxiredoxin ;C19359;Chlorinated;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Synechocystis sp;K24158;prx;thioredoxin-dependent peroxiredoxin ;C19359;Nitrogen-containing;PSL;Chloramine;thioredoxin-dependent peroxiredoxin
+Synechocystis sp;K13051;ASRGL1;L-asparaginase / beta-aspartyl-peptidase ;C00014;Nitrogen-containing;PSL;Ammonia;asparaginase
+Synechocystis sp;K13051;ASRGL1;L-asparaginase / beta-aspartyl-peptidase ;C00014;Nitrogen-containing;ATSDR;Ammonia;asparaginase

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,9 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    pandas==2.2.0
-    numpy==1.26.4
-    plotly==5.18.0
+    pandas
+    numpy
+    plotly
     tqdm
     click
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 """
-    Setup file for biorempp.
-    Use setup.cfg to configure your project.
+Setup file for biorempp.
+Use setup.cfg to configure your project.
 
-    This file was generated with PyScaffold 4.6.
-    PyScaffold helps you to put up the scaffold of your new Python project.
-    Learn more under: https://pyscaffold.org/
+This file was generated with PyScaffold 4.6.
+PyScaffold helps you to put up the scaffold of your new Python project.
+Learn more under: https://pyscaffold.org/
 """
 
 from setuptools import setup

--- a/src/biorempp/pipelines/__init__.py
+++ b/src/biorempp/pipelines/__init__.py
@@ -1,0 +1,11 @@
+"""
+BioRemPP Pipeline Package
+
+Orchestrators for main BioRemPP analysis steps.
+"""
+
+from .input_processing import run_input_processing_pipeline
+
+__all__ = [
+    "run_input_processing_pipeline",
+]

--- a/src/biorempp/pipelines/input_processing.py
+++ b/src/biorempp/pipelines/input_processing.py
@@ -1,0 +1,78 @@
+"""
+Input Processing Pipeline for BioRemPP
+
+Pipeline to validate, process, and merge FASTA-like input with the BioRemPP
+database. The merged result is saved using a generic output function.
+"""
+
+import os
+
+from biorempp.input_processing.input_loader import load_and_merge_input
+from biorempp.utils.io_utils import save_dataframe_output
+
+
+def run_input_processing_pipeline(
+    input_path,
+    database_path=None,
+    output_dir="outputs/merged_data",
+    output_filename="merged_input.txt",
+    sep=";",
+    optimize_types=True,
+):
+    """
+    Run the input validation, merging, and save output as .txt.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to the input .txt file (FASTA-like format).
+    database_path : str or None
+        Path to the BioRemPP database CSV file. If None, uses default path.
+    output_dir : str
+        Directory where the merged DataFrame will be saved.
+    output_filename : str
+        Name of the output file.
+    sep : str
+        Separator for output (default: ';').
+    optimize_types : bool
+        Whether to optimize DataFrame dtypes (default: True).
+
+    Returns
+    -------
+    str
+        Path to the saved output file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the input file does not exist.
+    RuntimeError
+        If there is an error in processing or merging.
+    """
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    if database_path is None:
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        database_path = os.path.join(this_dir, "..", "data", "database_biorempp.csv")
+
+    with open(input_path, "r", encoding="utf-8") as f:
+        input_content = f.read()
+
+    df, error = load_and_merge_input(
+        input_content,
+        os.path.basename(input_path),
+        database_filepath=database_path,
+        optimize_types=optimize_types,
+    )
+
+    if error:
+        raise RuntimeError(f"Pipeline error: {error}")
+
+    output_path = save_dataframe_output(
+        df,
+        output_dir=output_dir,
+        filename=output_filename,
+        sep=sep,
+    )
+    return output_path

--- a/src/biorempp/utils/__init__.py
+++ b/src/biorempp/utils/__init__.py
@@ -1,0 +1,9 @@
+"""
+Utilities module for biorempp package.
+"""
+
+from .io_utils import save_dataframe_output
+
+__all__ = [
+    "save_dataframe_output",
+]

--- a/src/biorempp/utils/io_utils.py
+++ b/src/biorempp/utils/io_utils.py
@@ -1,0 +1,44 @@
+"""
+I/O Utilities for BioRemPP
+
+General functions for saving outputs to disk.
+"""
+
+import os
+
+
+def save_dataframe_output(
+    df,
+    output_dir,
+    filename,
+    sep=";",
+    index=False,
+    encoding="utf-8",
+):
+    """
+    Save a DataFrame to a txt/csv file in the given directory.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to save.
+    output_dir : str
+        Directory to save the file (created if it doesn't exist).
+    filename : str
+        Name of the output file.
+    sep : str
+        Separator for the output file (default: ';').
+    index : bool
+        Whether to write row indices (default: False).
+    encoding : str
+        File encoding (default: 'utf-8').
+
+    Returns
+    -------
+    str
+        Path to the saved file.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, filename)
+    df.to_csv(output_path, sep=sep, index=index, encoding=encoding)
+    return output_path


### PR DESCRIPTION
- Create `save_dataframe_output` utility for generic DataFrame export with customizable path, filename, and separator
- Refactor input processing pipeline to use new utility and support flexible output configuration
- Organize output structure under `outputs/merged_data/` with option to expand for new types (figures, reports)
- Update main entrypoint to call pipeline only and remove direct DataFrame prints
- Improve docstrings and modularization for future extensibility
- Add `outputs/` to default output path if not specified

BREAKING CHANGE: Output saving is now handled by a generic utility, and print-to-terminal behavior was replaced by file export. Main now delegates to pipeline function.
