### PR TITLE
feat: add automated semantic-release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+
+    - name: Test with tox
+      run: tox
+
+    - name: Run flake8 linting
+      run: |
+        pip install flake8
+        flake8 src/ tests/ --max-line-length=88 --extend-ignore=E203,W503
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.10'
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+
+    - name: Test with tox
+      run: tox
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check distribution
+      run: twine check dist/*
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-distributions
+        path: dist/
+
+  release:
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "lts/*"
+
+    - name: Install semantic-release
+      run: |
+        npm install -g semantic-release@^22.0.0
+        npm install -g @semantic-release/changelog@^6.0.0
+        npm install -g @semantic-release/git@^10.0.0
+        npm install -g @semantic-release/github@^9.0.0
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: python-distributions
+        path: dist/
+
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      run: npx semantic-release

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,11 @@ MANIFEST
 .venv*/
 .conda*/
 .python-version
+
+# Node.js dependencies for semantic-release
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+yarn.lock

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,140 @@
+{
+  "preset": "conventionalcommits",
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {
+            "type": "docs",
+            "release": false
+          },
+          {
+            "type": "test",
+            "release": false
+          },
+          {
+            "type": "style",
+            "release": false
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "revert",
+            "release": "patch"
+          },
+          {
+            "breaking": true,
+            "release": "major"
+          }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "feat",
+              "section": "🚀 Features"
+            },
+            {
+              "type": "fix",
+              "section": "🐛 Bug Fixes"
+            },
+            {
+              "type": "perf",
+              "section": "⚡ Performance Improvements"
+            },
+            {
+              "type": "revert",
+              "section": "⏪ Reverts"
+            },
+            {
+              "type": "docs",
+              "section": "📚 Documentation",
+              "hidden": false
+            },
+            {
+              "type": "style",
+              "section": "💎 Styles",
+              "hidden": true
+            },
+            {
+              "type": "refactor",
+              "section": "📦 Code Refactoring"
+            },
+            {
+              "type": "test",
+              "section": "🚨 Tests",
+              "hidden": true
+            },
+            {
+              "type": "build",
+              "section": "🛠 Build System",
+              "hidden": true
+            },
+            {
+              "type": "ci",
+              "section": "⚙️ Continuous Integration",
+              "hidden": true
+            }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines."
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "dist/*.tar.gz",
+            "label": "Python Source Distribution"
+          },
+          {
+            "path": "dist/*.whl",
+            "label": "Python Wheel Distribution"
+          }
+        ],
+        "successComment": "🎉 This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} 🎉\n\nThe release is available on:\n- [GitHub Releases](${releases.filter(release => !!release.name).map(release => `[${release.name}](${release.url})`).join('\\n- ')})\n\nYour **${issue.pull_request ? 'pull request' : 'issue'}** is in **${nextRelease.gitTag}** 🚀"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "package.json"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -119,3 +119,154 @@ This project has been set up using [PyScaffold] 4.6 and the [dsproject extension
 [Google style]: http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings
 [PyScaffold]: https://pyscaffold.org/
 [dsproject extension]: https://github.com/pyscaffold/pyscaffoldext-dsproject
+
+## Development & Contributing
+
+### 📋 Commit Guidelines
+
+This project follows [Conventional Commits](https://conventionalcommits.org/) specification for automated versioning and changelog generation.
+
+#### Commit Message Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+#### Commit Types
+
+- **feat**: A new feature (triggers minor version bump)
+- **fix**: A bug fix (triggers patch version bump)
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code
+- **refactor**: Code change that neither fixes a bug nor adds a feature
+- **perf**: Code change that improves performance
+- **test**: Adding missing tests or correcting existing tests
+- **build**: Changes that affect the build system or external dependencies
+- **ci**: Changes to CI configuration files and scripts
+- **chore**: Other changes that don't modify src or test files
+- **revert**: Reverts a previous commit
+
+#### Breaking Changes
+
+For breaking changes, add `!` after the type or add `BREAKING CHANGE:` in the footer:
+
+```bash
+feat!: redesign API interface
+
+BREAKING CHANGE: The API interface has been completely redesigned
+```
+
+#### Examples
+
+```bash
+# Feature addition (minor version bump)
+feat: add KEGG pathway analysis functionality
+
+# Bug fix (patch version bump)
+fix: resolve memory leak in data processing pipeline
+
+# Breaking change (major version bump)
+feat!: migrate to new input validation system
+
+# Documentation update (no version bump)
+docs: update installation instructions
+```
+
+### 🚀 Release Process
+
+This project uses automated semantic versioning powered by [semantic-release](https://semantic-release.gitbook.io/).
+
+#### How Releases Work
+
+1. **Automatic**: Releases are automatically triggered on every push to the `main` branch
+2. **Version Calculation**: Based on conventional commit messages since the last release
+3. **Changelog**: Automatically generated and updated
+4. **GitHub Release**: Created with release notes and distribution files
+5. **Tags**: Git tags are automatically created and pushed
+
+#### Version Bumping Rules
+
+| Commit Type | Example | Version Bump |
+|-------------|---------|--------------|
+| `fix:` | `fix: resolve input validation bug` | Patch (1.0.0 → 1.0.1) |
+| `feat:` | `feat: add new analysis pipeline` | Minor (1.0.0 → 1.1.0) |
+| `feat!:` or `BREAKING CHANGE:` | `feat!: redesign API` | Major (1.0.0 → 2.0.0) |
+| `docs:`, `style:`, `test:` | `docs: update README` | No release |
+
+#### Manual Release
+
+If needed, you can trigger a release manually:
+
+```bash
+# Via GitHub Actions (recommended)
+gh workflow run release.yml
+
+# Or locally (requires setup)
+npm run semantic-release
+```
+
+### 🛠 Development Workflow
+
+1. **Fork and Clone**
+   ```bash
+   git clone https://github.com/DougFelipe/biorempp.git
+   cd biorempp
+   ```
+
+2. **Setup Environment**
+   ```bash
+   conda env create -f environment.yml
+   conda activate biorempp
+   pip install -e .
+   ```
+
+3. **Create Feature Branch**
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+
+4. **Make Changes and Test**
+   ```bash
+   # Run tests
+   pytest tests/
+
+   # Check code style
+   flake8 src/ tests/ --max-line-length=88
+
+   # Run all checks
+   tox
+   ```
+
+5. **Commit with Conventional Format**
+   ```bash
+   git add .
+   git commit -m "feat: add new feature description"
+   ```
+
+6. **Push and Create PR**
+   ```bash
+   git push origin feat/your-feature-name
+   # Create PR via GitHub UI
+   ```
+
+### 📦 Release Artifacts
+
+Each release automatically generates:
+
+- **Source Distribution** (`.tar.gz`)
+- **Wheel Distribution** (`.whl`)
+- **GitHub Release** with changelog
+- **Updated CHANGELOG.md**
+- **Git Tags** following semver
+
+### 🔧 Setup for Maintainers
+
+To enable automated releases, ensure the following secrets are configured in GitHub:
+
+- `GH_TOKEN`: Personal Access Token with `repo` and `write:packages` permissions
+
+For more details, see the [Contributing Guidelines](CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "biorempp",
+  "version": "0.0.0-development",
+  "description": "The Bioremediation Potential Profile (BioRemPP) is designed to explore the biotechnological potential of microbial, fungal, and plant genomes for bioremediation purposes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DougFelipe/biorempp.git"
+  },
+  "keywords": [
+    "bioinformatics",
+    "bioremediation",
+    "genomics",
+    "microbiology",
+    "biotechnology"
+  ],
+  "author": "Douglas Felipe",
+  "license": "Copyright (c) 2025 Douglas Felipe",
+  "bugs": {
+    "url": "https://github.com/DougFelipe/biorempp/issues"
+  },
+  "homepage": "https://github.com/DougFelipe/biorempp#readme",
+  "devDependencies": {
+    "semantic-release": "^22.0.0",
+    "@semantic-release/changelog": "^6.0.0",
+    "@semantic-release/git": "^10.0.0",
+    "@semantic-release/github": "^9.0.0"
+  },
+  "release": {
+    "branches": [
+      "main"
+    ]
+  },
+  "scripts": {
+    "semantic-release": "semantic-release"
+  }
+}

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,176 @@
+/**
+ * Semantic Release Configuration
+ *
+ * This file provides advanced configuration options for semantic-release
+ * beyond what's available in .releaserc.json
+ */
+
+const releaseConfig = {
+  branches: [
+    'main',
+    {
+      name: 'develop',
+      prerelease: 'beta',
+      channel: 'beta'
+    },
+    {
+      name: 'alpha',
+      prerelease: 'alpha',
+      channel: 'alpha'
+    }
+  ],
+
+  plugins: [
+    // Analyze commits to determine release type
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'conventionalcommits',
+        releaseRules: [
+          // Custom release rules
+          { type: 'docs', release: false },
+          { type: 'test', release: false },
+          { type: 'style', release: false },
+          { type: 'refactor', release: 'patch' },
+          { type: 'perf', release: 'patch' },
+          { type: 'fix', release: 'patch' },
+          { type: 'feat', release: 'minor' },
+          { type: 'revert', release: 'patch' },
+          { breaking: true, release: 'major' },
+
+          // Custom scopes for specific release types
+          { scope: 'deps', type: 'fix', release: 'patch' },
+          { scope: 'deps', type: 'feat', release: 'minor' },
+
+          // Security fixes always trigger patch release
+          { type: 'fix', scope: 'security', release: 'patch' },
+        ],
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING']
+        }
+      }
+    ],
+
+    // Generate release notes
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'conventionalcommits',
+        presetConfig: {
+          types: [
+            { type: 'feat', section: '🚀 Features' },
+            { type: 'fix', section: '🐛 Bug Fixes' },
+            { type: 'perf', section: '⚡ Performance Improvements' },
+            { type: 'revert', section: '⏪ Reverts' },
+            { type: 'docs', section: '📚 Documentation', hidden: false },
+            { type: 'style', section: '💎 Styles', hidden: true },
+            { type: 'refactor', section: '📦 Code Refactoring' },
+            { type: 'test', section: '🚨 Tests', hidden: true },
+            { type: 'build', section: '🛠 Build System', hidden: true },
+            { type: 'ci', section: '⚙️ Continuous Integration', hidden: true },
+            { type: 'chore', section: '🔧 Maintenance', hidden: true }
+          ]
+        },
+        writerOpts: {
+          // Custom commit transform for better release notes
+          transform: (commit, context) => {
+            const issues = []
+
+            commit.notes.forEach(note => {
+              note.title = '💥 BREAKING CHANGES'
+            })
+
+            if (commit.scope === '*') {
+              commit.scope = ''
+            }
+
+            if (typeof commit.hash === 'string') {
+              commit.shortHash = commit.hash.substring(0, 7)
+            }
+
+            if (typeof commit.subject === 'string') {
+              let url = context.repository
+                ? `${context.host}/${context.owner}/${context.repository}`
+                : context.repoUrl
+              if (url) {
+                url = `${url}/issues/`
+                // Issue URLs
+                commit.subject = commit.subject.replace(/#([0-9]+)/g, (_, issue) => {
+                  issues.push(issue)
+                  return `[#${issue}](${url}${issue})`
+                })
+              }
+              if (context.host) {
+                // User URLs
+                commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/])*)/g, (_, username) => {
+                  if (username.includes('/')) {
+                    return `@${username}`
+                  }
+                  return `[@${username}](${context.host}/${username})`
+                })
+              }
+            }
+
+            // Remove duplicate issues
+            commit.references = commit.references.filter(reference => {
+              if (issues.indexOf(reference.issue) === -1) {
+                return true
+              }
+              return false
+            })
+
+            return commit
+          }
+        }
+      }
+    ],
+
+    // Update CHANGELOG.md
+    [
+      '@semantic-release/changelog',
+      {
+        changelogFile: 'CHANGELOG.md',
+        changelogTitle: '# Changelog\n\nAll notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.'
+      }
+    ],
+
+    // Create GitHub release
+    [
+      '@semantic-release/github',
+      {
+        assets: [
+          {
+            path: 'dist/*.tar.gz',
+            label: 'Python Source Distribution'
+          },
+          {
+            path: 'dist/*.whl',
+            label: 'Python Wheel Distribution'
+          }
+        ],
+        successComment: `🎉 This \${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version \${nextRelease.version} 🎉
+
+The release is available on:
+- [GitHub Releases](\${releases.filter(release => !!release.name).map(release => \`[\${release.name}](\${release.url})\`).join('\\n- ')})
+
+Your **\${issue.pull_request ? 'pull request' : 'issue'}** is in **\${nextRelease.gitTag}** 🚀`,
+        failComment: false,
+        failTitle: false,
+        labels: false,
+        releasedLabels: ['released'],
+        addReleases: 'bottom'
+      }
+    ],
+
+    // Commit back to repository
+    [
+      '@semantic-release/git',
+      {
+        assets: ['CHANGELOG.md', 'package.json'],
+        message: 'chore(release): \${nextRelease.version} [skip ci]\\n\\n\${nextRelease.notes}'
+      }
+    ]
+  ]
+}
+
+module.exports = releaseConfig

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,10 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    pandas==2.2.0
-    numpy==1.26.4
-    plotly==5.18.0
+    pandas>=2.0.0,<3.0.0
+    numpy>=1.21.0,<1.25.0; python_version<"3.9"
+    numpy>=1.21.0,<2.0.0; python_version>="3.9"
+    plotly>=5.0.0,<6.0.0
     tqdm
     click
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,12 @@
 [tox]
-envlist = py311
+envlist = py38, py39, py310, py311
+
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 setenv =


### PR DESCRIPTION
- Add semantic-release configuration with conventional commits preset
- Configure GitHub Actions workflows for CI/CD and automated releases
- Add npm package.json with semantic-release dependencies
- Update .gitignore to exclude Node.js artifacts
- Add comprehensive release documentation to README.md

This enables automatic versioning, changelog generation, and GitHub releases based on conventional commit messages. Releases will be triggered automatically on push to main branch after successful CI tests.